### PR TITLE
Add support for 403 responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@ gradle-app.setting
 out/
 classes/
 .idea_modules/
+
+### Eclipse stuff
+.project
+.settings
+.classpath

--- a/riposte-spi/src/main/java/com/nike/backstopper/handler/riposte/listener/impl/BackstopperRiposteFrameworkErrorHandlerListener.java
+++ b/riposte-spi/src/main/java/com/nike/backstopper/handler/riposte/listener/impl/BackstopperRiposteFrameworkErrorHandlerListener.java
@@ -13,6 +13,7 @@ import com.nike.internal.util.Pair;
 import com.nike.internal.util.StringUtils;
 import com.nike.riposte.server.error.exception.DownstreamChannelClosedUnexpectedlyException;
 import com.nike.riposte.server.error.exception.DownstreamIdleChannelTimeoutException;
+import com.nike.riposte.server.error.exception.Forbidden403Exception;
 import com.nike.riposte.server.error.exception.HostnameResolutionException;
 import com.nike.riposte.server.error.exception.InvalidCharsetInContentTypeHeaderException;
 import com.nike.riposte.server.error.exception.MethodNotAllowed405Exception;
@@ -168,6 +169,19 @@ public class BackstopperRiposteFrameworkErrorHandlerListener implements ApiExcep
             extraDetails.addAll((theEx).extraDetailsForLogging);
             return ApiExceptionHandlerListenerResult.handleResponse(
                 singletonError(projectApiErrors.getUnauthorizedApiError()),
+                extraDetails
+            );
+        }
+        
+        if (ex instanceof Forbidden403Exception) {
+            Forbidden403Exception theEx = (Forbidden403Exception) ex;
+            List<Pair<String, String>> extraDetails = new ArrayList<>();
+            extraDetails.add(Pair.of("message", ex.getMessage()));
+            extraDetails.add(Pair.of("incoming_request_path", theEx.requestPath));
+            extraDetails.add(Pair.of("authorization_header", theEx.authorizationHeader));
+            extraDetails.addAll((theEx).extraDetailsForLogging);
+            return ApiExceptionHandlerListenerResult.handleResponse(
+                singletonError(projectApiErrors.getForbiddenApiError()),
                 extraDetails
             );
         }

--- a/riposte-spi/src/main/java/com/nike/riposte/server/error/exception/Forbidden403Exception.java
+++ b/riposte-spi/src/main/java/com/nike/riposte/server/error/exception/Forbidden403Exception.java
@@ -1,0 +1,37 @@
+/**
+ * 
+ */
+package com.nike.riposte.server.error.exception;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.nike.internal.util.Pair;
+
+/**
+ * Thrown when a request does not have a valid authorization header. Represents a HTTP 403 response code.
+ * 
+ * @author pevans
+ *
+ */
+public class Forbidden403Exception extends RuntimeException {
+
+    public final String requestPath;
+    public final String authorizationHeader;
+    public final List<Pair<String, String>> extraDetailsForLogging;
+    
+    public Forbidden403Exception(String message, String requestPath, String authorizationHeader) {
+        this(message, requestPath, authorizationHeader, new ArrayList<>());
+    }
+
+    public Forbidden403Exception(String message, String requestPath, String authorizationHeader,
+                                    List<Pair<String, String>> extraDetailsForLogging) {
+        super(message);
+
+        this.requestPath = requestPath;
+        this.authorizationHeader = authorizationHeader;
+        this.extraDetailsForLogging = extraDetailsForLogging;
+    }
+	private static final long serialVersionUID = 4921880566299500314L;
+
+}

--- a/riposte-spi/src/main/java/com/nike/riposte/server/error/exception/Forbidden403Exception.java
+++ b/riposte-spi/src/main/java/com/nike/riposte/server/error/exception/Forbidden403Exception.java
@@ -32,6 +32,6 @@ public class Forbidden403Exception extends RuntimeException {
         this.authorizationHeader = authorizationHeader;
         this.extraDetailsForLogging = extraDetailsForLogging;
     }
-	private static final long serialVersionUID = 4921880566299500314L;
+    private static final long serialVersionUID = 4921880566299500314L;
 
 }

--- a/riposte-spi/src/test/java/com/nike/backstopper/handler/riposte/listener/impl/BackstopperRiposteFrameworkErrorHandlerListenerTest.java
+++ b/riposte-spi/src/test/java/com/nike/backstopper/handler/riposte/listener/impl/BackstopperRiposteFrameworkErrorHandlerListenerTest.java
@@ -11,6 +11,7 @@ import com.nike.fastbreak.exception.CircuitBreakerOpenException;
 import com.nike.fastbreak.exception.CircuitBreakerTimeoutException;
 import com.nike.riposte.server.error.exception.DownstreamChannelClosedUnexpectedlyException;
 import com.nike.riposte.server.error.exception.DownstreamIdleChannelTimeoutException;
+import com.nike.riposte.server.error.exception.Forbidden403Exception;
 import com.nike.riposte.server.error.exception.HostnameResolutionException;
 import com.nike.riposte.server.error.exception.InvalidCharsetInContentTypeHeaderException;
 import com.nike.riposte.server.error.exception.MethodNotAllowed405Exception;
@@ -142,6 +143,11 @@ public class BackstopperRiposteFrameworkErrorHandlerListenerTest {
     @Test
     public void should_handle_Unauthorized401Exception() {
         verifyExceptionHandled(new Unauthorized401Exception("foo", "/bar", "blah"), singletonError(testProjectApiErrors.getUnauthorizedApiError()));
+    }
+    
+    @Test
+    public void should_handle_Forbidden403Exception() {
+    	verifyExceptionHandled(new Forbidden403Exception("foo", "/bar", "blah"), singletonError(testProjectApiErrors.getForbiddenApiError()));
     }
 
     @Test

--- a/riposte-spi/src/test/java/com/nike/backstopper/handler/riposte/listener/impl/BackstopperRiposteFrameworkErrorHandlerListenerTest.java
+++ b/riposte-spi/src/test/java/com/nike/backstopper/handler/riposte/listener/impl/BackstopperRiposteFrameworkErrorHandlerListenerTest.java
@@ -147,7 +147,7 @@ public class BackstopperRiposteFrameworkErrorHandlerListenerTest {
     
     @Test
     public void should_handle_Forbidden403Exception() {
-    	verifyExceptionHandled(new Forbidden403Exception("foo", "/bar", "blah"), singletonError(testProjectApiErrors.getForbiddenApiError()));
+        verifyExceptionHandled(new Forbidden403Exception("foo", "/bar", "blah"), singletonError(testProjectApiErrors.getForbiddenApiError()));
     }
 
     @Test

--- a/riposte-spi/src/test/java/com/nike/riposte/server/error/exception/Forbidden403ExceptionTest.java
+++ b/riposte-spi/src/test/java/com/nike/riposte/server/error/exception/Forbidden403ExceptionTest.java
@@ -9,13 +9,13 @@ import org.junit.Test;
 
 public class Forbidden403ExceptionTest {
 
-	@Before
-	public void setUp() throws Exception {
-	}
+    @Before
+    public void setUp() throws Exception {
+    }
 
-	@Test
-	public void should_honor_constructor_params() {
-		//given
+    @Test
+    public void should_honor_constructor_params() {
+        //given
         String requestPath = UUID.randomUUID().toString();
         String authorizationHeader = UUID.randomUUID().toString();
         String message = UUID.randomUUID().toString();
@@ -27,6 +27,6 @@ public class Forbidden403ExceptionTest {
         assertThat(ex.getMessage(), is(message));
         assertThat(ex.requestPath, is(requestPath));
         assertThat(ex.authorizationHeader, is(authorizationHeader));
-	}
+    }
 
 }

--- a/riposte-spi/src/test/java/com/nike/riposte/server/error/exception/Forbidden403ExceptionTest.java
+++ b/riposte-spi/src/test/java/com/nike/riposte/server/error/exception/Forbidden403ExceptionTest.java
@@ -1,0 +1,32 @@
+package com.nike.riposte.server.error.exception;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import java.util.UUID;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class Forbidden403ExceptionTest {
+
+	@Before
+	public void setUp() throws Exception {
+	}
+
+	@Test
+	public void should_honor_constructor_params() {
+		//given
+        String requestPath = UUID.randomUUID().toString();
+        String authorizationHeader = UUID.randomUUID().toString();
+        String message = UUID.randomUUID().toString();
+
+        //when
+        Forbidden403Exception ex = new Forbidden403Exception(message, requestPath, authorizationHeader);
+
+        //then
+        assertThat(ex.getMessage(), is(message));
+        assertThat(ex.requestPath, is(requestPath));
+        assertThat(ex.authorizationHeader, is(authorizationHeader));
+	}
+
+}


### PR DESCRIPTION
This simple change allows 403 responses to be returned similar to the other 4xx HTTP responses.