### PR TITLE
Issue 11 - Decode path before setting in RequestInfoImpl

### DIFF
--- a/riposte-spi/src/main/java/com/nike/riposte/server/http/RequestInfo.java
+++ b/riposte-spi/src/main/java/com/nike/riposte/server/http/RequestInfo.java
@@ -40,14 +40,20 @@ public interface RequestInfo<T> {
     public static final Charset DEFAULT_CONTENT_CHARSET = CharsetUtil.UTF_8;
 
     /**
-     * The full URI associated with this request. May include the query string (use {@link #getPath()} if you don't want
-     * the query string). Will never be null - the empty string will be used if no URI information was provided.
+     * The full URI associated with this request. This will be the raw, potentially encoded, value sent to the server.
+     * It may include the query string (use {@link #getPath()} if you don't want the query string).
+     *
+     * Will never be null - the empty string will be used if no URI information was provided.
      */
     public String getUri();
 
     /**
      * The path-only portion of the URI. Will *not* include the query string (use {@link #getUri()} if you want the
-     * query string). Will never be null - the empty string will be used if no path information could be extracted.
+     * query string).
+     *
+     * The path value returned will be URL decoded before being returned.
+     *
+     * Will never be null - the empty string will be used if no path information could be extracted.
      */
     public String getPath();
 

--- a/riposte-spi/src/main/java/com/nike/riposte/server/http/impl/RequestInfoImpl.java
+++ b/riposte-spi/src/main/java/com/nike/riposte/server/http/impl/RequestInfoImpl.java
@@ -96,7 +96,7 @@ public class RequestInfoImpl<T> implements RequestInfo<T> {
             cookies = new HashSet<>();
 
         this.uri = uri;
-        this.path = HttpUtils.extractPath(uri);
+        this.path = QueryStringDecoder.decodeComponent(HttpUtils.extractPath(uri));
         this.method = method;
         this.headers = headers;
         this.trailingHeaders = trailingHeaders;


### PR DESCRIPTION
This PR fills the gap identified in issue #11 .

Decode the value before setting the path inside RequestInfoImpl.

After this is merged, when you call requestInfo.getPathParam("blah") it will be the decoded value where previously it was the raw, encoded value