### PR TITLE
Validate request size against global or endpoint provided max request size

### DIFF
--- a/riposte-core/src/main/java/com/nike/riposte/server/channelpipeline/HttpChannelInitializer.java
+++ b/riposte-core/src/main/java/com/nike/riposte/server/channelpipeline/HttpChannelInitializer.java
@@ -454,10 +454,6 @@ public class HttpChannelInitializer extends ChannelInitializer<SocketChannel> {
         // INBOUND - Access log start
         p.addLast(ACCESS_LOG_START_HANDLER_NAME, new AccessLogStartHandler());
 
-        // TODO: Now that HttpObjectAggregator is gone, we need to add a handler that counts incoming request bytes and
-        //       throws a TooLongFrameException the instant we detect that a chunk puts the total request size above
-        //       maxRequestSizeInBytes. Might be able to roll that functionality into RequestInfoSetterHandler
-
         // IN/OUT - Add SmartHttpContentCompressor for automatic content compression (if appropriate for the
         //          request/response/size threshold). This must be after HttpRequestDecoder on the incoming pipeline and
         //          before HttpResponseEncoder on the outbound pipeline (keep in mind that "before" on outbound means
@@ -466,7 +462,7 @@ public class HttpChannelInitializer extends ChannelInitializer<SocketChannel> {
         p.addLast(SMART_HTTP_CONTENT_COMPRESSOR_HANDLER_NAME, new SmartHttpContentCompressor(500));
 
         // INBOUND - Add RequestInfoSetterHandler to populate our request state with a RequestInfo object
-        p.addLast(REQUEST_INFO_SETTER_HANDLER_NAME, new RequestInfoSetterHandler());
+        p.addLast(REQUEST_INFO_SETTER_HANDLER_NAME, new RequestInfoSetterHandler(maxRequestSizeInBytes));
         // INBOUND - Add OpenChannelLimitHandler to limit the number of open incoming server channels, but only if
         //           maxOpenChannelsThreshold is not -1.
         if (maxOpenChannelsThreshold != -1) {

--- a/riposte-core/src/main/java/com/nike/riposte/server/http/ProxyRouterEndpoint.java
+++ b/riposte-core/src/main/java/com/nike/riposte/server/http/ProxyRouterEndpoint.java
@@ -230,4 +230,12 @@ public abstract class ProxyRouterEndpoint implements Endpoint {
             return this;
         }
     }
+
+    /**
+     * Proxy router endpoints don't generally want to limit the request size they are proxying, so return 0 to disable
+     */
+    @Override
+    public Integer maxRequestSizeInBytesOverride() {
+        return 0;
+    }
 }

--- a/riposte-core/src/test/java/com/nike/riposte/server/channelpipeline/HttpChannelInitializerTest.java
+++ b/riposte-core/src/test/java/com/nike/riposte/server/channelpipeline/HttpChannelInitializerTest.java
@@ -623,6 +623,8 @@ public class HttpChannelInitializerTest {
         assertThat(requestInfoSetterHandler, notNullValue());
 
         assertThat(requestInfoSetterHandler.getLeft(), is(greaterThan(httpContentCompressor.getLeft())));
+        //verify max size is passed through into RequestInfoSetterHandler
+        assertThat(extractField(requestInfoSetterHandler.getRight(), "globalConfiguredMaxRequestSizeInBytes"), is(42));
     }
 
     @Test

--- a/riposte-core/src/test/java/com/nike/riposte/server/componenttest/VerifyRequestSizeValidationComponentTest.java
+++ b/riposte-core/src/test/java/com/nike/riposte/server/componenttest/VerifyRequestSizeValidationComponentTest.java
@@ -1,0 +1,257 @@
+package com.nike.riposte.server.componenttest;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nike.riposte.server.http.*;
+import io.restassured.response.ExtractableResponse;
+import com.nike.riposte.server.Server;
+import com.nike.riposte.server.config.ServerConfig;
+import com.nike.riposte.server.testutils.ComponentTestUtils;
+import com.nike.riposte.util.Matcher;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import static com.nike.riposte.server.componenttest.VerifyRequestSizeValidationComponentTest.RequestSizeValidationConfig.GLOBAL_MAX_REQUEST_SIZE;
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class VerifyRequestSizeValidationComponentTest {
+
+
+    private static Server server;
+    private static ServerConfig serverConfig;
+    private static ObjectMapper objectMapper;
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        objectMapper = new ObjectMapper();
+        serverConfig = new RequestSizeValidationConfig();
+        server = new Server(serverConfig);
+        server.startup();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server.shutdown();
+    }
+
+    @Test
+    public void should_return_bad_request_when_request_exceeds_global_configured_max_request_size() throws IOException {
+        ExtractableResponse response =
+                given()
+                        .baseUri("http://127.0.0.1")
+                        .port(serverConfig.endpointsPort())
+                        .basePath(BasicEndpoint.MATCHING_PATH)
+                        .log().all()
+                        .body(generatePayloadOfSizeInBytes(GLOBAL_MAX_REQUEST_SIZE + 1))
+                        .when()
+                        .post()
+                        .then()
+                        .log().headers()
+                        .extract();
+
+        assertThat(response.statusCode()).isEqualTo(HttpResponseStatus.BAD_REQUEST.code());
+        assertBadRequestErrorMessageAndMetadata(response);
+    }
+
+    private void assertBadRequestErrorMessageAndMetadata(ExtractableResponse response) throws IOException {
+        JsonNode error = objectMapper.readValue(response.asString(), JsonNode.class).get("errors").get(0);
+        assertThat(error.get("message").textValue()).isEqualTo("Malformed request");
+        assertThat(error.get("metadata").get("cause").textValue())
+            .isEqualTo("The request exceeded the maximum payload size allowed");
+    }
+
+    @Test
+    public void should_return_expected_response_when_not_exceeding_global_request_size() {
+        ExtractableResponse response =
+                given()
+                        .baseUri("http://127.0.0.1")
+                        .port(serverConfig.endpointsPort())
+                        .basePath(BasicEndpoint.MATCHING_PATH)
+                        .log().all()
+                        .body(generatePayloadOfSizeInBytes(GLOBAL_MAX_REQUEST_SIZE))
+                        .when()
+                        .post()
+                        .then()
+                        .log().headers()
+                        .extract();
+
+        assertThat(response.statusCode()).isEqualTo(HttpResponseStatus.OK.code());
+        assertThat(response.asString()).isEqualTo(BasicEndpoint.RESPONSE_PAYLOAD);
+    }
+
+    @Test
+    public void should_return_bad_request_when_request_exceeds_endpoint_overridden_configured_max_request_size() throws IOException {
+        ExtractableResponse response =
+                given()
+                        .baseUri("http://127.0.0.1")
+                        .port(serverConfig.endpointsPort())
+                        .basePath(BasicEndpointWithRequestSizeValidationOverride.MATCHING_PATH)
+                        .log().all()
+                        .body(generatePayloadOfSizeInBytes(BasicEndpointWithRequestSizeValidationOverride.MAX_REQUEST_SIZE + 1))
+                        .when()
+                        .post()
+                        .then()
+                        .log().headers()
+                        .extract();
+
+        assertThat(response.statusCode()).isEqualTo(HttpResponseStatus.BAD_REQUEST.code());
+        assertBadRequestErrorMessageAndMetadata(response);
+    }
+
+    @Test
+    public void should_return_expected_response_when_not_exceeding_endpoint_overridden_request_size() {
+        ExtractableResponse response =
+                given()
+                        .baseUri("http://127.0.0.1")
+                        .port(serverConfig.endpointsPort())
+                        .basePath(BasicEndpointWithRequestSizeValidationOverride.MATCHING_PATH)
+                        .log().all()
+                        .body(generatePayloadOfSizeInBytes(BasicEndpointWithRequestSizeValidationOverride.MAX_REQUEST_SIZE))
+                        .when()
+                        .post()
+                        .then()
+                        .log().headers()
+                        .extract();
+
+        assertThat(response.statusCode()).isEqualTo(HttpResponseStatus.OK.code());
+        assertThat(response.asString()).isEqualTo(BasicEndpointWithRequestSizeValidationOverride.RESPONSE_PAYLOAD);
+    }
+
+    @Test
+    public void should_return_expected_response_when_endpoint_disabled_request_size_validation() {
+        ExtractableResponse response =
+                given()
+                        .baseUri("http://127.0.0.1")
+                        .port(serverConfig.endpointsPort())
+                        .basePath(BasicEndpointWithRequestSizeValidationDisabled.MATCHING_PATH)
+                        .log().all()
+                        .body(generatePayloadOfSizeInBytes(GLOBAL_MAX_REQUEST_SIZE + 100))
+                        .when()
+                        .post()
+                        .then()
+                        .log().headers()
+                        .extract();
+
+        assertThat(response.statusCode()).isEqualTo(HttpResponseStatus.OK.code());
+        assertThat(response.asString()).isEqualTo(BasicEndpointWithRequestSizeValidationDisabled.RESPONSE_PAYLOAD);
+    }
+
+    private static String generatePayloadOfSizeInBytes(int length) {
+        StringBuilder sb = new StringBuilder(length);
+        for(int i = 0; i < length; i++) {
+            sb.append(i % 10);
+        }
+        return sb.toString();
+    }
+
+    private static class BasicEndpoint extends StandardEndpoint<Void, String> {
+
+        public static final String MATCHING_PATH = "/basicEndpoint";
+        public static final String RESPONSE_PAYLOAD = "basic-endpoint-" + UUID.randomUUID().toString();
+
+        @Override
+        public CompletableFuture<ResponseInfo<String>> execute(RequestInfo<Void> request, Executor longRunningTaskExecutor, ChannelHandlerContext ctx) {
+            return CompletableFuture.completedFuture(
+                    ResponseInfo.newBuilder(RESPONSE_PAYLOAD).build()
+            );
+        }
+
+        @Override
+        public Matcher requestMatcher() {
+            return Matcher.match(MATCHING_PATH, HttpMethod.POST);
+        }
+    }
+
+    private static class BasicEndpointWithRequestSizeValidationOverride extends StandardEndpoint<Void, String> {
+
+        public static final String MATCHING_PATH = "/basicEndpointWithOverride";
+        public static final String RESPONSE_PAYLOAD = "basic-endpoint-" + UUID.randomUUID().toString();
+        public static Integer MAX_REQUEST_SIZE = 10;
+
+        @Override
+        public CompletableFuture<ResponseInfo<String>> execute(RequestInfo<Void> request, Executor longRunningTaskExecutor, ChannelHandlerContext ctx) {
+            return CompletableFuture.completedFuture(
+                    ResponseInfo.newBuilder(RESPONSE_PAYLOAD).build()
+            );
+        }
+
+        @Override
+        public Matcher requestMatcher() {
+            return Matcher.match(MATCHING_PATH, HttpMethod.POST);
+        }
+
+        @Override
+        public Integer maxRequestSizeInBytesOverride() {
+            return MAX_REQUEST_SIZE;
+        }
+    }
+
+    private static class BasicEndpointWithRequestSizeValidationDisabled extends StandardEndpoint<Void, String> {
+
+        public static final String MATCHING_PATH = "/basicEndpointWithRequestSizeValidationDisabled";
+        public static final String RESPONSE_PAYLOAD = "basic-endpoint-" + UUID.randomUUID().toString();
+        public static Integer MAX_REQUEST_SIZE = 0;
+
+        @Override
+        public CompletableFuture<ResponseInfo<String>> execute(RequestInfo<Void> request, Executor longRunningTaskExecutor, ChannelHandlerContext ctx) {
+            return CompletableFuture.completedFuture(
+                    ResponseInfo.newBuilder(RESPONSE_PAYLOAD).build()
+            );
+        }
+
+        @Override
+        public Matcher requestMatcher() {
+            return Matcher.match(MATCHING_PATH, HttpMethod.POST);
+        }
+
+        @Override
+        public Integer maxRequestSizeInBytesOverride() {
+            return MAX_REQUEST_SIZE;
+        }
+    }
+
+    public static class RequestSizeValidationConfig implements ServerConfig {
+        private final Collection<Endpoint<?>> endpoints = Arrays.asList(new BasicEndpoint(),
+                new BasicEndpointWithRequestSizeValidationOverride(),
+                new BasicEndpointWithRequestSizeValidationDisabled());
+
+        private final int port;
+        public static int GLOBAL_MAX_REQUEST_SIZE = 5;
+
+        public RequestSizeValidationConfig() {
+            try {
+                port = ComponentTestUtils.findFreePort();
+            } catch (IOException e) {
+                throw new RuntimeException("Couldn't allocate port", e);
+            }
+        }
+
+        @Override
+        public int maxRequestSizeInBytes() {
+            return GLOBAL_MAX_REQUEST_SIZE;
+        }
+
+        @Override
+        public Collection<Endpoint<?>> appEndpoints() {
+            return endpoints;
+        }
+
+        @Override
+        public int endpointsPort() {
+            return port;
+        }
+    }
+
+}

--- a/riposte-core/src/test/java/com/nike/riposte/server/handler/RequestInfoSetterHandlerTest.java
+++ b/riposte-core/src/test/java/com/nike/riposte/server/handler/RequestInfoSetterHandlerTest.java
@@ -2,9 +2,19 @@ package com.nike.riposte.server.handler;
 
 import com.nike.riposte.server.channelpipeline.ChannelAttributes;
 import com.nike.riposte.server.handler.base.PipelineContinuationBehavior;
+import com.nike.riposte.server.http.Endpoint;
 import com.nike.riposte.server.http.HttpProcessingState;
 import com.nike.riposte.server.http.RequestInfo;
 
+import io.netty.handler.codec.TooLongFrameException;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpObject;
+import io.netty.handler.codec.http.HttpVersion;
+
+import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -12,14 +22,10 @@ import org.mockito.ArgumentCaptor;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.http.DefaultHttpHeaders;
-import io.netty.handler.codec.http.FullHttpRequest;
-import io.netty.handler.codec.http.HttpHeaders;
-import io.netty.handler.codec.http.HttpObject;
-import io.netty.handler.codec.http.HttpVersion;
 import io.netty.util.Attribute;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -32,11 +38,16 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
  */
 public class RequestInfoSetterHandlerTest {
 
-    private RequestInfoSetterHandler handler = new RequestInfoSetterHandler();;
+    private RequestInfoSetterHandler handler;
     private HttpProcessingState stateMock;
     private ChannelHandlerContext ctxMock;
     private Channel channelMock;
     private Attribute<HttpProcessingState> stateAttrMock;
+    private Endpoint<?> endpointMock;
+    private HttpContent httpContent;
+    private ByteBuf byteBufMock;
+    private int maxRequestSizeInBytes;
+    private RequestInfo<?> requestInfo;
 
     @Before
     public void beforeMethod() {
@@ -44,10 +55,26 @@ public class RequestInfoSetterHandlerTest {
         ctxMock = mock(ChannelHandlerContext.class);
         channelMock = mock(Channel.class);
         stateAttrMock = mock(Attribute.class);
+        endpointMock = mock(Endpoint.class);
+        maxRequestSizeInBytes = 10;
+        httpContent = mock(HttpContent.class);
+        byteBufMock = mock(ByteBuf.class);
+        requestInfo = mock(RequestInfo.class);
+
+        handler = new RequestInfoSetterHandler(maxRequestSizeInBytes);
 
         doReturn(channelMock).when(ctxMock).channel();
         doReturn(stateAttrMock).when(channelMock).attr(ChannelAttributes.HTTP_PROCESSING_STATE_ATTRIBUTE_KEY);
         doReturn(stateMock).when(stateAttrMock).get();
+        doReturn(endpointMock).when(stateMock).getEndpointForExecution();
+        doReturn(byteBufMock).when(httpContent).content();
+        doReturn(null).when(endpointMock).maxRequestSizeInBytesOverride();
+        doReturn(requestInfo).when(stateMock).getRequestInfo();
+    }
+
+    @Test
+    public void argsAreEligibleForLinkingAndUnlinkingDistributedTracingInfo_should_return_false() {
+        assertThat(handler.argsAreEligibleForLinkingAndUnlinkingDistributedTracingInfo(null, null, null, null)).isFalse();
     }
 
     @Test
@@ -56,7 +83,6 @@ public class RequestInfoSetterHandlerTest {
         FullHttpRequest msgMock = mock(FullHttpRequest.class);
         String uri = "/some/url";
         HttpHeaders headers = new DefaultHttpHeaders();
-        ByteBuf byteBufMock = mock(ByteBuf.class);
         doReturn(uri).when(msgMock).getUri();
         doReturn(headers).when(msgMock).headers();
         doReturn(headers).when(msgMock).trailingHeaders();
@@ -91,6 +117,104 @@ public class RequestInfoSetterHandlerTest {
         verifyNoMoreInteractions(stateMock);
         verifyNoMoreInteractions(msgMock);
         assertThat(result).isEqualTo(PipelineContinuationBehavior.CONTINUE);
+    }
+
+    @Test
+    public void doChannelRead_returns_do_not_fire_when_null_state() {
+        // given
+        doReturn(true).when(stateMock).isResponseSendingLastChunkSent();
+
+        // when
+        PipelineContinuationBehavior result = handler.doChannelRead(ctxMock, httpContent);
+
+        // then
+        assertThat(result).isEqualTo(PipelineContinuationBehavior.DO_NOT_FIRE_CONTINUE_EVENT);
+    }
+
+    @Test
+    public void doChannelRead_throws_exception_when_no_request_info_when_HttpContent_message() {
+        // given
+        doReturn(null).when(stateMock).getRequestInfo();
+
+        // when
+        Throwable thrownException = Assertions.catchThrowable(() -> handler.doChannelRead(ctxMock, httpContent));
+
+        // then
+        assertThat(thrownException).isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void doChannelRead_does_not_throw_exception_when_exceeding_global_max_size_when_request_validation_is_turned_off() {
+        // given
+        maxRequestSizeInBytes = 10;
+        handler = new RequestInfoSetterHandler(maxRequestSizeInBytes);
+        doReturn(0).when(endpointMock).maxRequestSizeInBytesOverride();
+        doReturn(100).when(requestInfo).addContentChunk(anyObject());
+
+        // when
+        PipelineContinuationBehavior result = handler.doChannelRead(ctxMock, httpContent);
+
+        // then
+        assertThat(result).isEqualTo(PipelineContinuationBehavior.CONTINUE);
+    }
+
+    @Test
+    public void doChannelRead_allows_endpoints_to_override_max_request_size_setting_lower() {
+        // given
+        maxRequestSizeInBytes = 10;
+        handler = new RequestInfoSetterHandler(maxRequestSizeInBytes);
+        doReturn(1).when(endpointMock).maxRequestSizeInBytesOverride();
+        doReturn(2).when(requestInfo).addContentChunk(anyObject());
+
+        // when
+        Throwable thrownException = Assertions.catchThrowable(() -> handler.doChannelRead(ctxMock, httpContent));
+
+        // then
+        assertThat(thrownException).isExactlyInstanceOf(TooLongFrameException.class);
+    }
+
+    @Test
+    public void doChannelRead_allows_endpoints_to_override_max_request_size_setting_higher() {
+        // given
+        maxRequestSizeInBytes = 10;
+        handler = new RequestInfoSetterHandler(maxRequestSizeInBytes);
+        doReturn(100).when(endpointMock).maxRequestSizeInBytesOverride();
+        doReturn(99).when(requestInfo).addContentChunk(anyObject());
+
+        // when
+        PipelineContinuationBehavior result = handler.doChannelRead(ctxMock, httpContent);
+
+        // then
+        assertThat(result).isEqualTo(PipelineContinuationBehavior.CONTINUE);
+    }
+
+    @Test
+    public void doChannelRead_no_endpoint_override_uses_global_configured_max_request_size_no_error() {
+        // given
+        maxRequestSizeInBytes = 10;
+        handler = new RequestInfoSetterHandler(maxRequestSizeInBytes);
+        doReturn(5).when(requestInfo).addContentChunk(anyObject());
+
+        // when
+        PipelineContinuationBehavior result = handler.doChannelRead(ctxMock, httpContent);
+
+        // then
+        assertThat(result).isEqualTo(PipelineContinuationBehavior.CONTINUE);
+    }
+
+    @Test
+    public void doChannelRead_no_endpoint_override_uses_global_configured_max_request_size() {
+        // given
+        maxRequestSizeInBytes = 10;
+        handler = new RequestInfoSetterHandler(maxRequestSizeInBytes);
+
+        doReturn(11).when(requestInfo).addContentChunk(anyObject());
+
+        // when
+        Throwable thrownException = Assertions.catchThrowable(() -> handler.doChannelRead(ctxMock, httpContent));
+
+        // then
+        assertThat(thrownException).isExactlyInstanceOf(TooLongFrameException.class);
     }
 
 }

--- a/riposte-spi/src/main/java/com/nike/riposte/server/config/ServerConfig.java
+++ b/riposte-spi/src/main/java/com/nike/riposte/server/config/ServerConfig.java
@@ -390,12 +390,14 @@ public interface ServerConfig {
     /**
      * @return The maximum allowed request size in bytes. If netty receives a request larger than this then it will
      * throw a {@link io.netty.handler.codec.TooLongFrameException}.
+     *
      * This value is an integer, so the max you can set it to is {@link Integer#MAX_VALUE}, which corresponds to 2^31-1,
      * or 2147483647 (around 2 GB).
-     * <p><b>NOTE: This feature is currently disabled - this value will do nothing at the moment.</b>
+     *
+     * A value of 0 or less is disabling the max request size validation. Defaulting to no limit.
      */
     default int maxRequestSizeInBytes() {
-        return Integer.MAX_VALUE;
+        return 0;
     }
 
     /**

--- a/riposte-spi/src/main/java/com/nike/riposte/server/http/Endpoint.java
+++ b/riposte-spi/src/main/java/com/nike/riposte/server/http/Endpoint.java
@@ -117,4 +117,16 @@ public interface Endpoint<I> {
         return null;
     }
 
+    /**
+     * @return The max request size in bytes that you want to allow for this specific endpoint, or null if you want to
+     * use the app-wide default max request size returned by {@link ServerConfig#maxRequestSizeInBytes()}.
+     *
+     * If you would like to disable validation on this endpoint, return 0 or less.
+     *
+     * If you would like to default to the global configured limit, return null.
+     */
+    default Integer maxRequestSizeInBytesOverride() {
+        // Return null by default so that the app-wide max request size will be used unless you override this method.
+        return null;
+    }
 }

--- a/riposte-spi/src/main/java/com/nike/riposte/server/http/RequestInfo.java
+++ b/riposte-spi/src/main/java/com/nike/riposte/server/http/RequestInfo.java
@@ -292,18 +292,18 @@ public interface RequestInfo<T> {
     public boolean isKeepAliveRequested();
 
     /**
-     * Adds the given content chunk to the list of chunks this instance is tracking. When this method detects that the
-     * passed-in chunk is the last chunk in the request it will mark this request so that {@link
-     * #isCompleteRequestWithAllChunks()} will return true. Once this is done, the first subsequent call to {@link
-     * #getRawContentBytes()} will convert all the chunks into a byte array and return it from then on. This
-     * lazy-loading style protects us from loading the bytes and (very temporarily) doubling the memory necessary to
-     * store it in the case that the request never causes {@link #getRawContentBytes()} to be called. NOTE: Calling
-     * {@link #getRawContent()} is even worse memory-wise since it converts the bytes into a string and caches the
-     * result. This is also true for {@link #getContent()}, however raw bytes are usually not useful and endpoints need
-     * to inspect the data somehow, so the utility of the deserialized object usually pushes users in favor of {@link
-     * #getContent()} rather than {@link #getRawContent()}. Just understand that those methods are lazy-loading, so if
-     * you don't need to call {@link #getRawContent()} or {@link #getContent()} (or both) then you can save some memory
-     * while the endpoint is executing.
+     * Adds the given content chunk to the list of chunks this instance is tracking and returns current request size
+     * in bytes after adding this chunk. When this method detects that the passed-in chunk is the last chunk in the
+     * request it will mark this request so that {@link #isCompleteRequestWithAllChunks()} will return true.
+     * Once this is done, the first subsequent call to {@link #getRawContentBytes()} will convert all the chunks into
+     * a byte array and return it from then on. This lazy-loading style protects us from loading the bytes and
+     * (very temporarily) doubling the memory necessary to store it in the case that the request never causes
+     * {@link #getRawContentBytes()} to be called. NOTE: Calling {@link #getRawContent()} is even worse memory-wise
+     * since it converts the bytes into a string and caches the result. This is also true for {@link #getContent()},
+     * however raw bytes are usually not useful and endpoints need to inspect the data somehow, so the utility of the
+     * deserialized object usually pushes users in favor of {@link #getContent()} rather than {@link #getRawContent()}.
+     * Just understand that those methods are lazy-loading, so if you don't need to call {@link #getRawContent()} or
+     * {@link #getContent()} (or both) then you can save some memory while the endpoint is executing.
      * <p/>
      * When the last chunk is detected this method will also set {@link #getTrailingHeaders()} to whatever trailing
      * headers were contained in the last chunk.
@@ -320,7 +320,7 @@ public interface RequestInfo<T> {
      * final chunk being added or in the case that the request never causes {@link #getRawContentBytes()} to be called.
      * Individual endpoints do not need to worry about this issue - it's a problem for the server to solve.
      */
-    public void addContentChunk(HttpContent chunk);
+    public int addContentChunk(HttpContent chunk);
 
     /**
      * Returns true if this request represents a 100% complete request with all chunks and trailing headers populated,

--- a/riposte-spi/src/main/java/com/nike/riposte/server/http/impl/RequestInfoImpl.java
+++ b/riposte-spi/src/main/java/com/nike/riposte/server/http/impl/RequestInfoImpl.java
@@ -386,7 +386,7 @@ public class RequestInfoImpl<T> implements RequestInfo<T> {
      * {@inheritDoc}
      */
     @Override
-    public void addContentChunk(HttpContent chunk) {
+    public int addContentChunk(HttpContent chunk) {
         if (isCompleteRequestWithAllChunks) {
             throw new IllegalStateException("Cannot add new content chunk - this RequestInfo is already marked as "
                                             + "representing the complete request with all chunks");
@@ -413,6 +413,8 @@ public class RequestInfoImpl<T> implements RequestInfo<T> {
                 trailingHeaders.add(chunkTrailingHeaders);
             }
         }
+
+        return rawContentLengthInBytes;
     }
 
     /**

--- a/riposte-spi/src/test/java/com/nike/backstopper/handler/riposte/listener/impl/BackstopperRiposteFrameworkErrorHandlerListenerTest.java
+++ b/riposte-spi/src/test/java/com/nike/backstopper/handler/riposte/listener/impl/BackstopperRiposteFrameworkErrorHandlerListenerTest.java
@@ -187,6 +187,14 @@ public class BackstopperRiposteFrameworkErrorHandlerListenerTest {
     }
 
     @Test
+    public void shouldHandleTooLongFrameExceptionAndAddCauseMetadata() {
+        ApiExceptionHandlerListenerResult result = listener.shouldHandleException(new TooLongFrameException());
+        assertThat(result.shouldHandleResponse).isTrue();
+        assertThat(result.errors).isEqualTo(singletonError(testProjectApiErrors.getMalformedRequestApiError()));
+        assertThat(result.errors.first().getMetadata().get("cause")).isEqualTo("The request exceeded the maximum payload size allowed");
+    }
+
+    @Test
     public void should_handle_IncompleteHttpCallTimeoutException() {
         verifyExceptionHandled(new IncompleteHttpCallTimeoutException(4242), singletonError(testProjectApiErrors.getMalformedRequestApiError()));
     }

--- a/riposte-spi/src/test/java/com/nike/riposte/server/config/ServerConfigTest.java
+++ b/riposte-spi/src/test/java/com/nike/riposte/server/config/ServerConfigTest.java
@@ -46,7 +46,7 @@ public class ServerConfigTest {
         assertThat(defaultImpl.riposteUnhandledErrorHandler(), notNullValue());
         assertThat(defaultImpl.numBossThreads(), is(1));
         assertThat(defaultImpl.numWorkerThreads(), is(0));
-        assertThat(defaultImpl.maxRequestSizeInBytes(), is(Integer.MAX_VALUE));
+        assertThat(defaultImpl.maxRequestSizeInBytes(), is(0));
         assertThat(defaultImpl.createSslContext(), notNullValue());
         assertThat(defaultImpl.requestContentValidationService(), nullValue());
         assertThat(defaultImpl.isDebugActionsEnabled(), is(false));

--- a/riposte-spi/src/test/java/com/nike/riposte/server/http/RequestInfoTest.java
+++ b/riposte-spi/src/test/java/com/nike/riposte/server/http/RequestInfoTest.java
@@ -240,8 +240,8 @@ public class RequestInfoTest {
         }
 
         @Override
-        public void addContentChunk(HttpContent chunk) {
-
+        public int addContentChunk(HttpContent chunk) {
+            return 0;
         }
 
         @Override


### PR DESCRIPTION
issue #27 

This PR will add the functionality of validating each request against a globally configured request size.

By default, endpoints do not override and will default to the global.

You can override the global configuration inside each endpoint.

ProxyRouterEndpoints have this validation disabled by default