### PR TITLE
[WIP] Add support for chunked response in Nonblocking Endpoint

### DIFF
--- a/riposte-core/src/main/java/com/nike/riposte/server/handler/NonblockingEndpointExecutionHandler.java
+++ b/riposte-core/src/main/java/com/nike/riposte/server/handler/NonblockingEndpointExecutionHandler.java
@@ -1,7 +1,7 @@
 package com.nike.riposte.server.handler;
 
 import com.nike.riposte.server.channelpipeline.ChannelAttributes;
-import com.nike.riposte.server.channelpipeline.message.LastOutboundMessageSendFullResponseInfo;
+import com.nike.riposte.server.channelpipeline.message.*;
 import com.nike.riposte.server.error.exception.NonblockingEndpointCompletableFutureTimedOut;
 import com.nike.riposte.server.handler.base.BaseInboundHandlerWithTracingAndMdcSupport;
 import com.nike.riposte.server.handler.base.PipelineContinuationBehavior;
@@ -11,6 +11,7 @@ import com.nike.riposte.server.http.NonblockingEndpoint;
 import com.nike.riposte.server.http.RequestInfo;
 import com.nike.riposte.server.http.ResponseInfo;
 
+import com.nike.riposte.server.http.impl.ChunkedResponseInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -167,12 +168,21 @@ public class NonblockingEndpointExecutionHandler extends BaseInboundHandlerWithT
         HttpProcessingState state = ChannelAttributes.getHttpProcessingStateForChannel(ctx).get();
 
         if (responseInfo.isChunkedResponse()) {
-            // Whoops, chunked responses are not allowed for this endpoint type.
-            asyncErrorCallback(
-                ctx,
-                new Exception("NonblockingEndpoint execution resulted in a chunked ResponseInfo, when only full "
-                              + "ResponseInfos are allowed. offending_endpoint_class=" +
-                              state.getEndpointForExecution().getClass().getName())
+            state.setResponseInfo(responseInfo);
+            executeOnlyIfChannelIsActive(
+                    ctx, "NonblockingEndpointExecutionHandler-asyncCallback",
+                    () -> {
+                        ctx.fireChannelRead(OutboundMessageSendHeadersChunkFromResponseInfo.INSTANCE);
+                        ChunkedResponseInfo info = (ChunkedResponseInfo) responseInfo;
+                        info.writer.accept(content -> {
+                            if (content instanceof LastHttpContent) {
+                                ctx.fireChannelRead(new LastOutboundMessageSendLastContentChunk((LastHttpContent) content));
+                            }
+                            else {
+                                ctx.fireChannelRead(new OutboundMessageSendContentChunk(content));
+                            }
+                        });
+                    }
             );
         }
         else {


### PR DESCRIPTION
Based on https://github.com/Nike-Inc/riposte/issues/38

Didn't find too much time to work on this over the weekend. Just got the very basics working. Still need to decide on an interface as having `Consumer<Consumer<HttpContent>>` probably isn't the best option.

TODO
- [ ] determine interface for sending chunks
- [ ] update `ProxyRouterEndpointExecutionHandler.StreamingCallbackForCtx` to use interface rather than passing chunks directly to `ctx.fireChannelRead`
- [ ] write tests

Thoughts

As mentioned in https://github.com/Nike-Inc/riposte/issues/38, we could just have `sendChunk(...)` and `sendLastChunk(...)`. Would we want to have the arguments be `HttpContent`? It may just be my inexperience with Netty but I can't seem to find a clean way to construct a ByteBuff for the HttpContent constructor.

If we care about back pressure, it might be cool to have an interface where Netty signals that it's ready to receive data for the caller and we simply push bytes into the provided ByteBuff. I'm not sure if this is doable, need to read up on the docs.

It might be awhile before I get back to this.