### PR TITLE
Fix ByteBuf memory leaks, race conditions, corner case error handling

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,12 @@
+# Controls the behavior of the codecov.io integration.
+# See https://github.com/codecov/support/wiki/Codecov-Yaml for details on the options.
+coverage:
+  status:
+    project:
+      default:
+        enabled: yes
+        target: 85%
+    patch:
+      default:
+        enabled: yes
+        target: 90%

--- a/riposte-core/src/main/java/com/nike/riposte/client/asynchttp/netty/StreamingAsyncHttpClient.java
+++ b/riposte-core/src/main/java/com/nike/riposte/client/asynchttp/netty/StreamingAsyncHttpClient.java
@@ -42,6 +42,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ChannelPromise;
 import io.netty.channel.CombinedChannelDuplexHandler;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.SimpleChannelInboundHandler;
@@ -138,12 +139,23 @@ public class StreamingAsyncHttpClient {
         protected final Channel channel;
         protected final ChannelPool pool;
         protected final ObjectHolder<Boolean> callActiveHolder;
+        protected final ObjectHolder<Boolean> downstreamLastChunkSentHolder;
+        protected final Deque<Span> distributedTracingSpanStack;
+        protected final Map<String, String> distributedTracingMdcInfo;
         protected boolean channelClosedDueToUnrecoverableError = false;
 
-        StreamingChannel(Channel channel, ChannelPool pool, ObjectHolder<Boolean> callActiveHolder) {
+        StreamingChannel(Channel channel,
+                         ChannelPool pool,
+                         ObjectHolder<Boolean> callActiveHolder,
+                         ObjectHolder<Boolean> downstreamLastChunkSentHolder,
+                         Deque<Span> distributedTracingSpanStack,
+                         Map<String, String> distributedTracingMdcInfo) {
             this.channel = channel;
             this.pool = pool;
             this.callActiveHolder = callActiveHolder;
+            this.downstreamLastChunkSentHolder = downstreamLastChunkSentHolder;
+            this.distributedTracingSpanStack = distributedTracingSpanStack;
+            this.distributedTracingMdcInfo = distributedTracingMdcInfo;
         }
 
         /**
@@ -158,28 +170,170 @@ public class StreamingAsyncHttpClient {
          * @return The {@link ChannelFuture} that will tell you if the write succeeded.
          */
         public ChannelFuture streamChunk(HttpContent chunkToWrite) {
-            if (channelClosedDueToUnrecoverableError) {
-                chunkToWrite.release();
-                return channel.newFailedFuture(new RuntimeException(
-                    "Unable to stream chunks downstream - "
-                    + "the channel was closed previously due to an unrecoverable error"
-                ));
-            }
+            try {
+                ChannelPromise result = channel.newPromise();
 
-            return channel.writeAndFlush(chunkToWrite);
+                channel.eventLoop().execute(
+                    () -> doStreamChunk(chunkToWrite).addListener(future -> {
+                        if (future.isCancelled()) {
+                            result.cancel(true);
+                        }
+                        else if (future.isSuccess()) {
+                            result.setSuccess();
+                        }
+                        else if (future.cause() != null) {
+                            result.setFailure(future.cause());
+                        }
+                        else {
+                            runnableWithTracingAndMdc(
+                                () -> logger.error(
+                                    "Found a future with no result. This should not be possible. Failing the future. "
+                                    + "future_done={}, future_success={}, future_cancelled={}, future_failure_cause={}",
+                                    future.isDone(), future.isSuccess(), future.isCancelled(), future.cause()
+                                ),
+                                distributedTracingSpanStack, distributedTracingMdcInfo
+                            ).run();
+                            result.setFailure(
+                                new RuntimeException("Received ChannelFuture that was in an impossible state")
+                            );
+                        }
+                    })
+                );
+
+                return result;
+            }
+            catch(Throwable t) {
+                String errorMsg =
+                    "StreamingChannel.streamChunk() threw an exception. This should not be possible and indicates "
+                    + "something went wrong with a Netty write() and flush(). If you see Netty memory leak warnings "
+                    + "then this could be why. Please report this along with the stack trace to "
+                    + "https://github.com/Nike-Inc/riposte/issues/new";
+
+                Exception exceptionToPass = new RuntimeException(errorMsg, t);
+
+                logger.error(errorMsg, exceptionToPass);
+                return channel.newFailedFuture(exceptionToPass);
+            }
         }
 
-        public void closeChannelDueToUnrecoverableError() {
-            channelClosedDueToUnrecoverableError = true;
+        protected ChannelFuture doStreamChunk(HttpContent chunkToWrite) {
+            // We are in the channel's event loop. Do some final checks to make sure it's still ok to write and flush
+            //      the message, then do it (or handle the special cases appropriately).
+            try {
+                if (downstreamLastChunkSentHolder.heldObject
+                    && (chunkToWrite instanceof LastHttpContent)
+                    && chunkToWrite.content().readableBytes() == 0
+                    ) {
+                    // A LastHttpContent has already been written downstream. This is valid/legal when the downstream call
+                    //      has a content-length header, and the downstream pipeline encoder realizes there's no more
+                    //      content to write and generates a synthetic empty LastHttpContent rather than waiting for this
+                    //      one to arrive. Therefore there's nothing to do but release the content chunk and return an
+                    //      already-successfully-completed future.
+                    if (logger.isDebugEnabled()) {
+                        runnableWithTracingAndMdc(
+                            () -> logger.warn("Ignoring zero-length LastHttpContent from upstream, because a "
+                                              + "LastHttpContent has already been sent downstream."),
+                            distributedTracingSpanStack, distributedTracingMdcInfo
+                        ).run();
+                    }
+                    chunkToWrite.release();
+                    return channel.newSucceededFuture();
+                }
 
-            // Mark the channel as broken so it will be closed and removed from the pool when it is returned.
-            markChannelAsBroken(channel);
+                if (!callActiveHolder.heldObject) {
+                    chunkToWrite.release();
+                    return channel.newFailedFuture(
+                        new RuntimeException("Unable to stream chunk - downstream call is no longer active.")
+                    );
+                }
 
-            // Release it back to the pool if possible/necessary so the pool can do its usual cleanup.
-            releaseChannelBackToPoolIfCallIsActive(channel, pool, callActiveHolder);
+                if (channelClosedDueToUnrecoverableError) {
+                    chunkToWrite.release();
+                    return channel.newFailedFuture(
+                        new RuntimeException("Unable to stream chunks downstream - the channel was closed previously "
+                                             + "due to an unrecoverable error")
+                    );
+                }
 
-            // No matter what the cause is we want to make sure the channel is closed.
-            channel.close();
+                return channel.writeAndFlush(chunkToWrite);
+            }
+            catch(Throwable t) {
+                String errorMsg =
+                    "StreamingChannel.doStreamChunk() threw an exception. This should not be possible and indicates "
+                    + "something went wrong with a Netty write() and flush(). If you see Netty memory leak warnings "
+                    + "then this could be why. Please report this along with the stack trace to "
+                    + "https://github.com/Nike-Inc/riposte/issues/new";
+
+                Exception exceptionToPass = new RuntimeException(errorMsg, t);
+
+                logger.error(errorMsg, exceptionToPass);
+                return channel.newFailedFuture(exceptionToPass);
+            }
+        }
+
+        private static final Logger logger = LoggerFactory.getLogger(StreamingChannel.class);
+
+        public Channel getChannel() {
+            return channel;
+        }
+
+        public void closeChannelDueToUnrecoverableError(Throwable cause) {
+            try {
+                // Ignore subsequent calls to this method, and only try to do something if the call is still active.
+                //      If the call is *not* active, then everything has already been cleaned up and we shouldn't
+                //      do anything because the channel might have already been handed out for a different call.
+                if (!channelClosedDueToUnrecoverableError && callActiveHolder.heldObject) {
+                    // Schedule the close on the channel's event loop.
+                    channel.eventLoop().execute(() -> doCloseChannelDueToUnrecoverableError(cause));
+                }
+
+                if (logger.isDebugEnabled()) {
+                    runnableWithTracingAndMdc(
+                        () -> logger.debug(
+                            "Ignoring call to StreamingChannel.closeChannelDueToUnrecoverableError() because it "
+                            + "has already been called, or the call is no longer active. "
+                            + "previously_called={}, call_is_active={}",
+                            channelClosedDueToUnrecoverableError, callActiveHolder.heldObject
+                        ),
+                        distributedTracingSpanStack, distributedTracingMdcInfo
+                    ).run();
+                }
+            }
+            finally {
+                channelClosedDueToUnrecoverableError = true;
+            }
+        }
+
+        protected void doCloseChannelDueToUnrecoverableError(Throwable cause) {
+            // We should now be in the channel's event loop. Do a final check to make sure the call is still active
+            //      since it could have closed while we were waiting to run on the event loop.
+            if (callActiveHolder.heldObject) {
+                runnableWithTracingAndMdc(
+                    () -> logger.error("Closing StreamingChannel due to unrecoverable error. "
+                                       + "channel_id={}, unrecoverable_error={}",
+                                       channel.toString(), String.valueOf(cause)
+                    ),
+                    distributedTracingSpanStack, distributedTracingMdcInfo
+                ).run();
+
+                // Mark the channel as broken so it will be closed and removed from the pool when it is returned.
+                markChannelAsBroken(channel);
+
+                // Release it back to the pool if possible/necessary so the pool can do its usual cleanup.
+                releaseChannelBackToPoolIfCallIsActive(
+                    channel, pool, callActiveHolder,
+                    "closing StreamingChannel due to unrecoverable error: " + String.valueOf(cause),
+                    distributedTracingSpanStack, distributedTracingMdcInfo
+                );
+
+                // No matter what the cause is we want to make sure the channel is closed.
+                channel.close();
+            }
+            else {
+                logger.debug("The call deactivated before we could close the StreamingChannel. Therefore there's "
+                             + "nothing to do for this unrecoverable error as any necessary cleanup has already been "
+                             + "done. ignored_unrecoverable_error={}", cause.toString());
+            }
         }
     }
 
@@ -532,11 +686,13 @@ public class StreamingAsyncHttpClient {
                     try {
                         ObjectHolder<Boolean> callActiveHolder = new ObjectHolder<>();
                         callActiveHolder.heldObject = true;
+                        ObjectHolder<Boolean> lastChunkSentDownstreamHolder = new ObjectHolder<>();
+                        lastChunkSentDownstreamHolder.heldObject = false;
                         //noinspection ConstantConditions
                         prepChannelForDownstreamCall(
                             pool, ch, callback, distributedSpanStackToUse, mdcContextToUse, isSecureHttpsCall,
                             relaxedHttpsValidation, performSubSpanAroundDownstreamCalls, downstreamCallTimeoutMillis,
-                            callActiveHolder
+                            callActiveHolder, lastChunkSentDownstreamHolder
                         );
 
                         logInitialRequestChunk(initialRequestChunk, downstreamHost, downstreamPort);
@@ -548,7 +704,10 @@ public class StreamingAsyncHttpClient {
                         //      for any further chunk streaming
                         writeFuture.addListener(completedWriteFuture -> {
                             if (completedWriteFuture.isSuccess())
-                                streamingChannel.complete(new StreamingChannel(ch, pool, callActiveHolder));
+                                streamingChannel.complete(new StreamingChannel(
+                                    ch, pool, callActiveHolder, lastChunkSentDownstreamHolder,
+                                    distributedSpanStackToUse, mdcContextToUse
+                                ));
                             else {
                                 prepChannelErrorHandler.accept(
                                     "Writing the first HttpRequest chunk to the downstream service failed.",
@@ -605,7 +764,7 @@ public class StreamingAsyncHttpClient {
         ChannelPool pool, Channel ch, StreamingCallback callback, Deque<Span> distributedSpanStackToUse,
         Map<String, String> mdcContextToUse, boolean isSecureHttpsCall, boolean relaxedHttpsValidation,
         boolean performSubSpanAroundDownstreamCalls, long downstreamCallTimeoutMillis,
-        ObjectHolder<Boolean> callActiveHolder
+        ObjectHolder<Boolean> callActiveHolder, ObjectHolder<Boolean> lastChunkSentDownstreamHolder
     ) throws SSLException, NoSuchAlgorithmException, KeyStoreException {
 
         ChannelHandler chunkSenderHandler = new SimpleChannelInboundHandler<HttpObject>() {
@@ -615,17 +774,21 @@ public class StreamingAsyncHttpClient {
                     // Only do the distributed trace and callback work if the call is active. Messages that pop up after
                     //      the call is fully processed should not trigger the behavior a second time.
                     if (callActiveHolder.heldObject) {
-                        if (msg instanceof LastHttpContent && performSubSpanAroundDownstreamCalls) {
-                            // Complete the subspan.
-                            runnableWithTracingAndMdc(
-                                () -> {
-                                    if (distributedSpanStackToUse == null || distributedSpanStackToUse.size() < 2)
-                                        Tracer.getInstance().completeRequestSpan();
-                                    else
-                                        Tracer.getInstance().completeSubSpan();
-                                },
-                                distributedSpanStackToUse, mdcContextToUse
-                            ).run();
+                        if (msg instanceof LastHttpContent) {
+                            lastChunkSentDownstreamHolder.heldObject = true;
+
+                            if (performSubSpanAroundDownstreamCalls) {
+                                // Complete the subspan.
+                                runnableWithTracingAndMdc(
+                                    () -> {
+                                        if (distributedSpanStackToUse == null || distributedSpanStackToUse.size() < 2)
+                                            Tracer.getInstance().completeRequestSpan();
+                                        else
+                                            Tracer.getInstance().completeSubSpan();
+                                    },
+                                    distributedSpanStackToUse, mdcContextToUse
+                                ).run();
+                            }
                         }
 
                         HttpObject msgToPass = msg;
@@ -662,8 +825,10 @@ public class StreamingAsyncHttpClient {
                     }
                 }
                 finally {
-                    if (msg instanceof LastHttpContent)
-                        releaseChannelBackToPoolIfCallIsActive(ch, pool, callActiveHolder);
+                    if (msg instanceof LastHttpContent) {
+                        releaseChannelBackToPoolIfCallIsActive(ch, pool, callActiveHolder, "last content chunk sent",
+                                                               distributedSpanStackToUse, mdcContextToUse);
+                    }
                 }
             }
         };
@@ -719,7 +884,10 @@ public class StreamingAsyncHttpClient {
                 markChannelAsBroken(ch);
 
                 // Release it back to the pool if possible/necessary so the pool can do its usual cleanup.
-                releaseChannelBackToPoolIfCallIsActive(ch, pool, callActiveHolder);
+                releaseChannelBackToPoolIfCallIsActive(
+                    ch, pool, callActiveHolder, "error received in downstream pipeline: " + cause.toString(),
+                    distributedSpanStackToUse, mdcContextToUse
+                );
 
                 // No matter what the cause is we want to make sure the channel is closed. Doing this raw ch.close()
                 //      here will catch the cases where this channel does not have an active call but still needs to be
@@ -739,6 +907,17 @@ public class StreamingAsyncHttpClient {
 
             @Override
             public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+                if (logger.isDebugEnabled()) {
+                    runnableWithTracingAndMdc(
+                        () -> logger.debug(
+                            "Downstream channel closing. call_active={}, last_chunk_sent_downstream={}, channel_id={}",
+                            callActiveHolder.heldObject, lastChunkSentDownstreamHolder.heldObject,
+                            ctx.channel().toString()
+                        ),
+                        distributedSpanStackToUse, mdcContextToUse
+                    ).run();
+                }
+
                 // We only care if the channel was closed while the call was active.
                 if (callActiveHolder.heldObject)
                     doErrorHandlingConsumer.accept(new DownstreamChannelClosedUnexpectedlyException(ch));
@@ -811,19 +990,25 @@ public class StreamingAsyncHttpClient {
             HttpClientCodec currentCodec = (HttpClientCodec) p.get(HTTP_CLIENT_CODEC_HANDLER_NAME);
             int currentHttpClientCodecInboundState = determineHttpClientCodecInboundState(currentCodec);
             if (currentHttpClientCodecInboundState != 0) {
-                logger.warn(
-                    "HttpClientCodec inbound state was not 0. It will be replaced with a fresh HttpClientCodec. "
-                    + "bad_httpclientcodec_inbound_state={}", currentHttpClientCodecInboundState
-                );
+                runnableWithTracingAndMdc(
+                    () -> logger.warn(
+                        "HttpClientCodec inbound state was not 0. It will be replaced with a fresh HttpClientCodec. "
+                        + "bad_httpclientcodec_inbound_state={}", currentHttpClientCodecInboundState
+                    ),
+                    distributedSpanStackToUse, mdcContextToUse
+                ).run();
                 existingHttpClientCodecIsInBadState = true;
             }
             else {
                 int currentHttpClientCodecOutboundState = determineHttpClientCodecOutboundState(currentCodec);
                 if (currentHttpClientCodecOutboundState != 0) {
-                    logger.warn(
-                        "HttpClientCodec outbound state was not 0. It will be replaced with a fresh HttpClientCodec. "
-                        + "bad_httpclientcodec_outbound_state={}", currentHttpClientCodecOutboundState
-                    );
+                    runnableWithTracingAndMdc(
+                        () -> logger.warn(
+                            "HttpClientCodec outbound state was not 0. It will be replaced with a fresh HttpClientCodec. "
+                            + "bad_httpclientcodec_outbound_state={}", currentHttpClientCodecOutboundState
+                        ),
+                        distributedSpanStackToUse, mdcContextToUse
+                    ).run();
                     existingHttpClientCodecIsInBadState = true;
                 }
             }
@@ -916,8 +1101,9 @@ public class StreamingAsyncHttpClient {
                 boolean channelAlreadyBroken = channelIsMarkedAsBeingBroken(ch);
                 logger.warn(
                     "HttpClientCodec inbound state was not 0. The channel will be marked as broken so it won't be "
-                    + "used. bad_httpclientcodec_inbound_state={}, channel_already_broken={}, call_context=\"{}\"",
-                    currentHttpClientCodecInboundState, channelAlreadyBroken, callContextForLogs
+                    + "used. bad_httpclientcodec_inbound_state={}, channel_already_broken={}, channel_id={}, "
+                    + "call_context=\"{}\"",
+                    currentHttpClientCodecInboundState, channelAlreadyBroken, ch.toString(), callContextForLogs
                 );
                 markChannelAsBroken(ch);
             }
@@ -927,8 +1113,9 @@ public class StreamingAsyncHttpClient {
                     boolean channelAlreadyBroken = channelIsMarkedAsBeingBroken(ch);
                     logger.warn(
                         "HttpClientCodec outbound state was not 0. The channel will be marked as broken so it won't be "
-                        + "used. bad_httpclientcodec_outbound_state={}, channel_already_broken={}, call_context=\"{}\"",
-                        currentHttpClientCodecOutboundState, channelAlreadyBroken, callContextForLogs
+                        + "used. bad_httpclientcodec_outbound_state={}, channel_already_broken={}, channel_id={}, "
+                        + "call_context=\"{}\"",
+                        currentHttpClientCodecOutboundState, channelAlreadyBroken, ch.toString(), callContextForLogs
                     );
                     markChannelAsBroken(ch);
                 }
@@ -945,8 +1132,21 @@ public class StreamingAsyncHttpClient {
     }
 
     protected static void releaseChannelBackToPoolIfCallIsActive(Channel ch, ChannelPool pool,
-                                                                 ObjectHolder<Boolean> callActiveHolder) {
+                                                                 ObjectHolder<Boolean> callActiveHolder,
+                                                                 String contextReason,
+                                                                 Deque<Span> distributedTracingStack,
+                                                                 Map<String, String> distributedTracingMdcInfo) {
         if (callActiveHolder.heldObject) {
+            if (logger.isDebugEnabled()) {
+                runnableWithTracingAndMdc(
+                    () -> logger.debug(
+                        "Marking call as inactive and releasing channel back to pool. "
+                        + "channel_release_reason=\"{}\"", contextReason
+                    ),
+                    distributedTracingStack, distributedTracingMdcInfo
+                ).run();
+            }
+
             callActiveHolder.heldObject = false;
             pool.release(ch);
         }

--- a/riposte-core/src/main/java/com/nike/riposte/server/handler/ChannelPipelineFinalizerHandler.java
+++ b/riposte-core/src/main/java/com/nike/riposte/server/handler/ChannelPipelineFinalizerHandler.java
@@ -7,20 +7,28 @@ import com.nike.riposte.server.error.handler.ErrorResponseBody;
 import com.nike.riposte.server.handler.base.BaseInboundHandlerWithTracingAndMdcSupport;
 import com.nike.riposte.server.handler.base.PipelineContinuationBehavior;
 import com.nike.riposte.server.http.HttpProcessingState;
+import com.nike.riposte.server.http.ProxyRouterProcessingState;
 import com.nike.riposte.server.http.RequestInfo;
 import com.nike.riposte.server.http.ResponseInfo;
 import com.nike.riposte.server.http.ResponseSender;
 import com.nike.riposte.server.metrics.ServerMetricsEvent;
+import com.nike.wingtips.Span;
+import com.nike.wingtips.Tracer;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandler;
+import io.netty.channel.ChannelOutboundHandler;
+import io.netty.channel.ChannelPromise;
 
 import static com.nike.riposte.server.channelpipeline.HttpChannelInitializer.IDLE_CHANNEL_TIMEOUT_HANDLER_NAME;
+import static com.nike.riposte.util.AsyncNettyHelper.runnableWithTracingAndMdc;
 
 /**
  * Finalizes incoming messages so that the pipeline considers the message handled and won't throw an error. This first
@@ -192,5 +200,94 @@ public class ChannelPipelineFinalizerHandler extends BaseInboundHandlerWithTraci
         if ((cause != null) && state.isResponseSendingStarted() && !state.isResponseSendingLastChunkSent()) {
             ctx.channel().close();
         }
+    }
+
+    /**
+     * This method is used as the final cleanup safety net for when a channel is closed. It guarantees that any
+     * {@link ByteBuf}s being held by {@link RequestInfo} or {@link ProxyRouterProcessingState} are {@link
+     * ByteBuf#release()}d so that we don't end up with a memory leak.
+     *
+     * <p>Note that we can't use {@link ChannelOutboundHandler#close(ChannelHandlerContext, ChannelPromise)} for this
+     * purpose as it is only called if we close the connection in our application code. It won't be triggered if
+     * (for example) the caller closes the connection, and we need it to *always* run for *every* closed connection,
+     * no matter the source of the close. {@link ChannelInboundHandler#channelInactive(ChannelHandlerContext)} is always
+     * called, so we're using that.
+     */
+    @Override
+    public PipelineContinuationBehavior doChannelInactive(ChannelHandlerContext ctx) throws Exception {
+        try {
+            // Grab hold of the things we may need when cleaning up.
+            HttpProcessingState httpState = ChannelAttributes.getHttpProcessingStateForChannel(ctx).get();
+            ProxyRouterProcessingState proxyRouterState =
+                ChannelAttributes.getProxyRouterProcessingStateForChannel(ctx).get();
+
+            RequestInfo<?> requestInfo = (httpState == null) ? null : httpState.getRequestInfo();
+            ResponseInfo<?> responseInfo = (httpState == null) ? null : httpState.getResponseInfo();
+
+            if (logger.isDebugEnabled()) {
+                runnableWithTracingAndMdc(
+                    () -> logger.debug("Cleaning up channel after it was closed. closed_channel_id={}",
+                                       ctx.channel().toString()),
+                    ctx
+                ).run();
+            }
+
+            // Handle the case where the response wasn't fully sent or tracing wasn't completed for some reason.
+            //      We want to finish the distributed tracing span for this request since there's no other place it
+            //      might be done, and if the request wasn't fully sent then we should spit out a log message so
+            //      debug investigations can find out what happened.
+            // TODO: Is there a way we can handle access logging and/or metrics here, but only if it wasn't done elsewhere?
+            @SuppressWarnings("SimplifiableConditionalExpression")
+            boolean tracingAlreadyCompleted = (httpState == null) ? true : httpState.isTraceCompletedOrScheduled();
+            boolean responseNotFullySent = responseInfo == null || !responseInfo.isResponseSendingLastChunkSent();
+            if (responseNotFullySent || !tracingAlreadyCompleted) {
+                runnableWithTracingAndMdc(
+                    () -> {
+                        if (responseNotFullySent) {
+                            logger.warn(
+                                "The caller's channel was closed before a response could be sent. This means that "
+                                + "an access log probably does not exist for this request. Distributed tracing "
+                                + "will be completed now if it wasn't already done. Any dangling resources will be "
+                                + "released."
+                            );
+                        }
+
+                        if (!tracingAlreadyCompleted) {
+                            Span currentSpan = Tracer.getInstance().getCurrentSpan();
+                            if (currentSpan != null && !currentSpan.isCompleted())
+                                Tracer.getInstance().completeRequestSpan();
+
+                            httpState.setTraceCompletedOrScheduled(true);
+                        }
+                    },
+                    ctx
+                ).run();
+            }
+
+            // Tell the RequestInfo it can release all its resources.
+            if (requestInfo != null)
+                requestInfo.releaseAllResources();
+
+            // Tell the ProxyRouterProcessingState that the stream failed and trigger its chunk streaming error handling
+            //      with an artificial exception. If the call had already succeeded previously then this will do
+            //      nothing, but if it hasn't already succeeded then it's not going to (since the connection is closing)
+            //      and doing this will cause any resources its holding onto to be released.
+            if (proxyRouterState != null) {
+                proxyRouterState.setStreamingFailed();
+                proxyRouterState.triggerStreamingChannelErrorForChunks(
+                    new RuntimeException("Server worker channel closed")
+                );
+            }
+        }
+        catch(Throwable t) {
+            runnableWithTracingAndMdc(
+                () -> logger.error(
+                    "An unexpected error occurred during ChannelPipelineFinalizerHandler.doChannelInactive() - this "
+                    + "should not happen and indicates a bug that needs to be fixed in Riposte.", t),
+                ctx
+            ).run();
+        }
+
+        return PipelineContinuationBehavior.CONTINUE;
     }
 }

--- a/riposte-core/src/main/java/com/nike/riposte/server/handler/ExceptionHandlingHandler.java
+++ b/riposte-core/src/main/java/com/nike/riposte/server/handler/ExceptionHandlingHandler.java
@@ -69,10 +69,13 @@ public class ExceptionHandlingHandler extends BaseInboundHandlerWithTracingAndMd
         //      processError call.
         HttpProcessingState state = getStateAndCreateIfNeeded(ctx, cause);
         if (state.isResponseSendingStarted()) {
-            logger.debug("A response has already been sent. Ignoring this caught exception. NOTE: This usually occurs "
-                         + "when an error happens on multiple chunks of the incoming request - only the first one is "
-                         + "processed into the error sent to the user. The original error is probably higher up in the "
-                         + "logs.");
+            logger.info(
+                "A response has already been started. Ignoring this exception since it's secondary. NOTE: This often "
+                + "occurs when an error happens repeatedly on multiple chunks of a request or response - only the "
+                + "first one is processed into the error sent to the user. The original error is probably higher up in "
+                + "the logs. ignored_secondary_exception=\"{}\"", cause.toString());
+
+            return PipelineContinuationBehavior.DO_NOT_FIRE_CONTINUE_EVENT;
         }
         else {
             ResponseInfo<ErrorResponseBody> responseInfo = processError(state, null, cause);

--- a/riposte-core/src/main/java/com/nike/riposte/server/handler/IdleChannelTimeoutHandler.java
+++ b/riposte-core/src/main/java/com/nike/riposte/server/handler/IdleChannelTimeoutHandler.java
@@ -1,8 +1,5 @@
 package com.nike.riposte.server.handler;
 
-import com.nike.riposte.server.channelpipeline.ChannelAttributes;
-import com.nike.riposte.server.http.HttpProcessingState;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,14 +34,7 @@ public class IdleChannelTimeoutHandler extends IdleStateHandler {
     protected void channelIdle(ChannelHandlerContext ctx, IdleStateEvent evt) throws Exception {
         channelIdleTriggered(ctx, evt);
 
-        // Release any state if possible.
-        HttpProcessingState state = ChannelAttributes.getHttpProcessingStateForChannel(ctx).get();
-        if (state != null) {
-            state.getRequestInfo().releaseAllResources();
-            state.cleanStateForNewRequest();
-        }
-
-        // Close the channel.
+        // Close the channel. ChannelPipelineFinalizerHandler.channelInactive(...) will ensure that content is released.
         ctx.channel().close();
 
         super.channelIdle(ctx, evt);

--- a/riposte-core/src/main/java/com/nike/riposte/server/handler/IdleChannelTimeoutHandler.java
+++ b/riposte-core/src/main/java/com/nike/riposte/server/handler/IdleChannelTimeoutHandler.java
@@ -46,10 +46,12 @@ public class IdleChannelTimeoutHandler extends IdleStateHandler {
      * log message.
      */
     protected void channelIdleTriggered(ChannelHandlerContext ctx, IdleStateEvent evt) {
-        logger.debug(
-            "Closing server channel due to idle timeout. "
-            + "custom_handler_id={}, idle_timeout_millis={}, worker_channel_being_closed={}",
-            customHandlerIdForLogs, idleTimeoutMillis, ctx.channel().toString()
-        );
+        if (logger.isDebugEnabled()) {
+            logger.debug(
+                "Closing server channel due to idle timeout. "
+                + "custom_handler_id={}, idle_timeout_millis={}, worker_channel_being_closed={}",
+                customHandlerIdForLogs, idleTimeoutMillis, ctx.channel().toString()
+            );
+        }
     }
 }

--- a/riposte-core/src/main/java/com/nike/riposte/server/handler/IncompleteHttpCallTimeoutHandler.java
+++ b/riposte-core/src/main/java/com/nike/riposte/server/handler/IncompleteHttpCallTimeoutHandler.java
@@ -53,12 +53,8 @@ public class IncompleteHttpCallTimeoutHandler extends IdleStateHandler {
 
         channelIdleTriggered(ctx, evt);
 
-        try {
-            throw new IncompleteHttpCallTimeoutException(idleTimeoutMillis);
-        }
-        finally {
-            alreadyTriggeredException = true;
-        }
+        alreadyTriggeredException = true;
+        throw new IncompleteHttpCallTimeoutException(idleTimeoutMillis);
     }
 
     protected void channelIdleTriggered(ChannelHandlerContext ctx, IdleStateEvent evt) {

--- a/riposte-core/src/main/java/com/nike/riposte/server/handler/IncompleteHttpCallTimeoutHandler.java
+++ b/riposte-core/src/main/java/com/nike/riposte/server/handler/IncompleteHttpCallTimeoutHandler.java
@@ -32,6 +32,7 @@ public class IncompleteHttpCallTimeoutHandler extends IdleStateHandler {
 
     private static final Logger logger = LoggerFactory.getLogger(IncompleteHttpCallTimeoutHandler.class);
     protected final long idleTimeoutMillis;
+    protected boolean alreadyTriggeredException = false;
 
     public IncompleteHttpCallTimeoutHandler(long idleTimeoutMillis) {
         super(0, 0, (int) idleTimeoutMillis, TimeUnit.MILLISECONDS);
@@ -40,9 +41,24 @@ public class IncompleteHttpCallTimeoutHandler extends IdleStateHandler {
 
     @Override
     protected void channelIdle(ChannelHandlerContext ctx, IdleStateEvent evt) throws Exception {
+        if (alreadyTriggeredException) {
+            runnableWithTracingAndMdc(
+                () -> logger.error(
+                    "IncompleteHttpCallTimeoutHandler triggered multiple times - this should not happen."
+                ),
+                ctx
+            ).run();
+            return;
+        }
+
         channelIdleTriggered(ctx, evt);
 
-        throw new IncompleteHttpCallTimeoutException(idleTimeoutMillis);
+        try {
+            throw new IncompleteHttpCallTimeoutException(idleTimeoutMillis);
+        }
+        finally {
+            alreadyTriggeredException = true;
+        }
     }
 
     protected void channelIdleTriggered(ChannelHandlerContext ctx, IdleStateEvent evt) {

--- a/riposte-core/src/main/java/com/nike/riposte/server/handler/ProxyRouterEndpointExecutionHandler.java
+++ b/riposte-core/src/main/java/com/nike/riposte/server/handler/ProxyRouterEndpointExecutionHandler.java
@@ -21,6 +21,7 @@ import com.nike.riposte.server.http.ProxyRouterEndpoint.DownstreamRequestFirstCh
 import com.nike.riposte.server.http.ProxyRouterProcessingState;
 import com.nike.riposte.server.http.RequestInfo;
 import com.nike.riposte.server.http.ResponseInfo;
+import com.nike.riposte.server.http.impl.RiposteInternalRequestInfo;
 import com.nike.riposte.util.AsyncNettyHelper;
 import com.nike.riposte.util.HttpUtils;
 import com.nike.wingtips.Span;
@@ -46,7 +47,8 @@ import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.Attribute;
-import io.netty.util.ReferenceCountUtil;
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.internal.OneTimeTask;
 
 import static com.nike.fastbreak.CircuitBreakerForHttpStatusCode.getDefaultHttpStatusCodeCircuitBreakerForKey;
 import static com.nike.riposte.util.AsyncNettyHelper.executeOnlyIfChannelIsActive;
@@ -113,6 +115,12 @@ public class ProxyRouterEndpointExecutionHandler extends BaseInboundHandlerWithT
             RequestInfo<?> requestInfo = state.getRequestInfo();
 
             if (msg instanceof HttpRequest) {
+                if (requestInfo instanceof RiposteInternalRequestInfo) {
+                    // Tell this RequestInfo that we'll be managing the release of content chunks, so that when
+                    //      RequestInfo.releaseAllResources() is called we don't have extra reference count removals.
+                    ((RiposteInternalRequestInfo)requestInfo).contentChunksWillBeReleasedExternally();
+                }
+
                 // We're supposed to start streaming. There may be pre-endpoint-execution validation logic or other work
                 //      that needs to happen before the endpoint is executed, so set up the CompletableFuture for the
                 //      endpoint call to only execute if the pre-endpoint-execution validation/work chain is successful.
@@ -140,13 +148,18 @@ public class ProxyRouterEndpointExecutionHandler extends BaseInboundHandlerWithT
                     );
                     if (throwable != null) {
                         // Something blew up trying to determine the first chunk info.
-                        try {
-                            callback.unrecoverableErrorOccurred(throwable);
-                        }
-                        finally {
-                            // Since something exploded before we could stream the first chunk, we're now done with it.
-                            ReferenceCountUtil.release(msg);
-                        }
+                        callback.unrecoverableErrorOccurred(throwable);
+                    }
+                    else if (!ctx.channel().isOpen()) {
+                        // The channel was closed for some reason before we were able to start streaming.
+                        String errorMsg = "The channel from the original caller was closed before we could begin the "
+                                          + "downstream call.";
+                        Exception channelClosedException = new RuntimeException(errorMsg);
+                        runnableWithTracingAndMdc(
+                            () -> logger.warn(errorMsg),
+                            ctx
+                        ).run();
+                        callback.unrecoverableErrorOccurred(channelClosedException);
                     }
                     else {
                         try {
@@ -191,27 +204,14 @@ public class ProxyRouterEndpointExecutionHandler extends BaseInboundHandlerWithT
 
                                 // Tell the streaming channel future what to do when it completes.
                                 streamingChannel = streamingChannel.whenComplete((sc, cause) -> {
-                                    try {
-                                        if (cause == null) {
-                                            // Successfully connected and sent the first chunk. We can now safely let
-                                            //      the remaining content chunks through for streaming.
-                                            proxyRouterState.triggerChunkProcessing(sc);
-                                        }
-                                        else {
-                                            // Something blew up while connecting to the downstream server.
-                                            callback.unrecoverableErrorOccurred(cause);
-                                            // We still have to finish the future for the chunks so that they can
-                                            //      release themselves.
-                                            proxyRouterState.triggerStreamingChannelErrorForChunks(cause);
-                                        }
+                                    if (cause == null) {
+                                        // Successfully connected and sent the first chunk. We can now safely let
+                                        //      the remaining content chunks through for streaming.
+                                        proxyRouterState.triggerChunkProcessing(sc);
                                     }
-                                    finally {
-                                        // At this point we're done with the first chunk whether the
-                                        //      connect-and-stream-first-chunk was successful or not. Release it, but
-                                        //      only if the streamingChannel was not successful. This is because on a
-                                        //      successful write the reference count is automatically reduced.
-                                        if (cause != null)
-                                            ReferenceCountUtil.release(msg);
+                                    else {
+                                        // Something blew up while connecting to the downstream server.
+                                        callback.unrecoverableErrorOccurred(cause);
                                     }
                                 });
                                 // Set the streaming channel future on the state so it can be connected to.
@@ -220,13 +220,7 @@ public class ProxyRouterEndpointExecutionHandler extends BaseInboundHandlerWithT
                             else {
                                 // Circuit breaker is tripped (or otherwise threw an unexpected exception). Immediately
                                 //      short circuit the error back to the client.
-                                try {
-                                    callback.unrecoverableErrorOccurred(circuitBreakerException);
-                                }
-                                finally {
-                                    // Since we exploded before we could stream the first chunk, we're now done with it.
-                                    ReferenceCountUtil.release(msg);
-                                }
+                                callback.unrecoverableErrorOccurred(circuitBreakerException);
                             }
                         }
                         catch (Throwable t) {
@@ -236,124 +230,179 @@ public class ProxyRouterEndpointExecutionHandler extends BaseInboundHandlerWithT
                 });
             }
             else if (msg instanceof HttpContent) {
-                // We have a content chunk to stream downstream. Attach the chunk processing to the proxyRouterState and
-                //      tell it to stream itself when that future says everything is ready.
-                proxyRouterState.registerStreamingChannelChunkProcessingAction((sc, cause) -> {
-                    if (cause == null) {
-                        // Nothing has blown up yet, so stream this next chunk downstream.
-                        ChannelFuture writeFuture = sc.streamChunks((HttpContent) msg);
-                        writeFuture.addListener(future -> {
-                            try {
-                                // The chunk streaming is complete, one way or another. React appropriately if there was
-                                //      a problem.
-                                if (!future.isSuccess()) {
-                                    String errorMsg = "Chunk streaming future came back as being unsuccessful.";
-                                    Throwable errorToFire = new WrapperException(errorMsg, future.cause());
-                                    sc.closeChannelDueToUnrecoverableError();
-                                    StreamingCallback callback = proxyRouterState.getStreamingCallback();
-                                    if (callback != null)
-                                        callback.unrecoverableErrorOccurred(errorToFire);
-                                    else {
-                                        runnableWithTracingAndMdc(
-                                            () -> logger.error(
-                                                "Unrecoverable error occurred and somehow the StreamingCallback was "
-                                                + "not available. This should not be possible. Firing the following "
-                                                + "error down the pipeline manually: " + errorMsg,
-                                                errorToFire),
-                                            ctx
-                                        ).run();
-                                        executeOnlyIfChannelIsActive(
-                                            ctx,
-                                            "ProxyRouterEndpointExecutionHandler-streamchunk-writefuture-unsuccessful",
-                                            () -> ctx.fireExceptionCaught(errorToFire)
-                                        );
-                                    }
-                                }
-                            }
-                            finally {
-                                // No matter what, at this point we're done with the chunk. Release it, but only if the
-                                //      writeFuture was not successful. This is because on a successful write the
-                                //      reference count is automatically reduced.
-                                if (!future.isSuccess())
-                                    ReferenceCountUtil.release(msg);
-                            }
-                        });
-                    }
-                    else {
-                        try {
-                            // Something blew up while attempting to send a chunk to the downstream server.
-                            StreamingChannel scToNotify = sc;
-                            if (scToNotify == null) {
-                                // No StreamingChannel from the registration future. Try to extract it from the
-                                //      proxyRouterState directly if possible.
-                                CompletableFuture<StreamingChannel> scFuture =
-                                    proxyRouterState.getStreamingChannelCompletableFuture();
-                                if (scFuture.isDone() && !scFuture.isCompletedExceptionally()) {
-                                    try {
-                                        scToNotify = scFuture.join();
-                                    }
-                                    catch (Throwable t) {
-                                        runnableWithTracingAndMdc(
-                                            () -> logger.error("What? This should never happen. Swallowing.", t), ctx
-                                        ).run();
-                                    }
-                                }
-                            }
+                HttpContent msgContent = (HttpContent)msg;
 
-                            if (scToNotify != null) {
-                                scToNotify.closeChannelDueToUnrecoverableError();
-                            }
-                            else {
-                                @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
-                                Throwable actualCause = unwrapAsyncExceptions(cause);
-                                if (!(actualCause instanceof WrapperException)) {
-                                    runnableWithTracingAndMdc(
-                                        () -> logger.error(
-                                            "Unable to extract StreamingChannel during error handling and the error "
-                                            + "that caused it was not a WrapperException, meaning "
-                                            + "StreamingAsyncHttpClient.streamDownstreamCall(...) did not properly "
-                                            + "handle it. This should likely never happen and might leave things in a "
-                                            + "bad state - it should be investigated and fixed! The error that caused "
-                                            + "this is: ",
-                                            cause),
-                                        ctx
-                                    ).run();
-                                }
-                            }
+                // releaseContentChunkIfStreamAlreadyFailed() will check if we already know that the downstream call
+                //      has already failed. If so then it will release the reference counts on the given HttpContent
+                //      and we're done. If not, then we call registerChunkStreamingAction() to set up the
+                //      chunk-streaming behavior and subsequent cleanup for the given HttpContent.
+                if (!releaseContentChunkIfStreamAlreadyFailed(msgContent, proxyRouterState)) {
+                    registerChunkStreamingAction(proxyRouterState, msgContent, requestInfo, ctx);
+                }
 
-                            String errorMsg = "Chunk streaming future came back as being unsuccessful.";
-                            Throwable errorToFire = new WrapperException(errorMsg, cause);
-
-                            StreamingCallback callback = proxyRouterState.getStreamingCallback();
-                            if (callback != null)
-                                callback.unrecoverableErrorOccurred(errorToFire);
-                            else {
-                                runnableWithTracingAndMdc(
-                                    () -> logger.error(
-                                        "Unrecoverable error occurred and somehow the StreamingCallback was not "
-                                        + "available. This should not be possible. Firing the following error down the "
-                                        + "pipeline manually: " + errorMsg,
-                                        errorToFire),
-                                    ctx
-                                ).run();
-                                executeOnlyIfChannelIsActive(
-                                    ctx, "ProxyRouterEndpointExecutionHandler-streamchunk-unsuccessful",
-                                    () -> ctx.fireExceptionCaught(errorToFire)
-                                );
-                            }
-                        }
-                        finally {
-                            // We no longer need the chunk so it can be released.
-                            ReferenceCountUtil.release(msg);
-                        }
-                    }
-                });
             }
 
             return PipelineContinuationBehavior.DO_NOT_FIRE_CONTINUE_EVENT;
         }
 
         return PipelineContinuationBehavior.CONTINUE;
+    }
+
+    protected void registerChunkStreamingAction(
+        ProxyRouterProcessingState proxyRouterState,
+        HttpContent msgContent,
+        RequestInfo<?> requestInfo,
+        ChannelHandlerContext ctx
+    ) {
+        // We have a content chunk to stream downstream. Attach the chunk processing to the proxyRouterState and
+        //      tell it to stream itself when that future says everything is ready.
+        proxyRouterState.registerStreamingChannelChunkProcessingAction((sc, cause) -> {
+            if (releaseContentChunkIfStreamAlreadyFailed(msgContent, proxyRouterState)) {
+                // An error occurred that means the downstream call failed and cannot continue. The error that caused
+                //      the failure will have been passed through the system and a response sent to the caller, and the
+                //      content has been released. Nothing left for us to do.
+                return;
+            }
+
+            if (cause == null) {
+                // Nothing has blown up yet, so stream this next chunk downstream. Calling streamChunk() will decrement
+                //      the chunk's reference count, allowing it to be destroyed since this should be the last handle
+                //      on the chunk's memory.
+                ChannelFuture writeFuture;
+                try {
+                    writeFuture = sc.streamChunk(msgContent);
+                }
+                catch(Throwable t) {
+                    logger.error(
+                        "StreamingAsyncHttpClient.streamChunk() threw an error. This should not be possible and "
+                        + "indicates something went wrong with a Netty write() and flush(). If you see Netty memory "
+                        + "leak warnings then this could be why. Please report this along with the stack trace to "
+                        + "https://github.com/Nike-Inc/riposte/issues/new",
+                        t
+                    );
+                    return;
+                }
+
+                writeFuture.addListener(future -> {
+                    // The chunk streaming is complete, one way or another. React appropriately if there was
+                    //      a problem.
+                    if (!future.isSuccess()) {
+                        String errorMsg = "Chunk streaming future came back as being unsuccessful.";
+                        Throwable errorToFire = new WrapperException(errorMsg, future.cause());
+                        sc.closeChannelDueToUnrecoverableError();
+                        StreamingCallback callback = proxyRouterState.getStreamingCallback();
+                        if (callback != null)
+                            callback.unrecoverableErrorOccurred(errorToFire);
+                        else {
+                            // We have to set proxyRouterState.setStreamingFailed() here since we couldn't
+                            //      call callback.unrecoverableErrorOccurred(...);
+                            proxyRouterState.setStreamingFailed();
+                            runnableWithTracingAndMdc(
+                                () -> logger.error(
+                                    "Unrecoverable error occurred and somehow the StreamingCallback was "
+                                    + "not available. This should not be possible. Firing the following "
+                                    + "error down the pipeline manually: " + errorMsg,
+                                    errorToFire),
+                                ctx
+                            ).run();
+                            executeOnlyIfChannelIsActive(
+                                ctx,
+                                "ProxyRouterEndpointExecutionHandler-streamchunk-writefuture-unsuccessful",
+                                () -> ctx.fireExceptionCaught(errorToFire)
+                            );
+                        }
+                    }
+                });
+            }
+            else {
+                try {
+                    // Something blew up while attempting to send a chunk to the downstream server.
+                    StreamingChannel scToNotify = sc;
+                    if (scToNotify == null) {
+                        // No StreamingChannel from the registration future. Try to extract it from the
+                        //      proxyRouterState directly if possible.
+                        CompletableFuture<StreamingChannel> scFuture =
+                            proxyRouterState.getStreamingChannelCompletableFuture();
+                        if (scFuture.isDone() && !scFuture.isCompletedExceptionally()) {
+                            try {
+                                scToNotify = scFuture.join();
+                            }
+                            catch (Throwable t) {
+                                runnableWithTracingAndMdc(
+                                    () -> logger.error("What? This should never happen. Swallowing.", t), ctx
+                                ).run();
+                            }
+                        }
+                    }
+
+                    if (scToNotify != null) {
+                        scToNotify.closeChannelDueToUnrecoverableError();
+                    }
+                    else {
+                        @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
+                        Throwable actualCause = unwrapAsyncExceptions(cause);
+                        if (!(actualCause instanceof WrapperException)) {
+                            runnableWithTracingAndMdc(
+                                () -> logger.error(
+                                    "Unable to extract StreamingChannel during error handling and the error "
+                                    + "that caused it was not a WrapperException, meaning "
+                                    + "StreamingAsyncHttpClient.streamDownstreamCall(...) did not properly "
+                                    + "handle it. This should likely never happen and might leave things in a "
+                                    + "bad state - it should be investigated and fixed! The error that caused "
+                                    + "this is: ",
+                                    cause),
+                                ctx
+                            ).run();
+                        }
+                    }
+
+                    String errorMsg = "Chunk streaming future came back as being unsuccessful.";
+                    Throwable errorToFire = new WrapperException(errorMsg, cause);
+
+                    StreamingCallback callback = proxyRouterState.getStreamingCallback();
+                    if (callback != null)
+                        callback.unrecoverableErrorOccurred(errorToFire);
+                    else {
+                        runnableWithTracingAndMdc(
+                            () -> logger.error(
+                                "Unrecoverable error occurred and somehow the StreamingCallback was not "
+                                + "available. This should not be possible. Firing the following error down the "
+                                + "pipeline manually: " + errorMsg,
+                                errorToFire),
+                            ctx
+                        ).run();
+                        executeOnlyIfChannelIsActive(
+                            ctx, "ProxyRouterEndpointExecutionHandler-streamchunk-unsuccessful",
+                            () -> ctx.fireExceptionCaught(errorToFire)
+                        );
+                    }
+                }
+                finally {
+                    // We were never able to call StreamingChannel.streamChunk() on this chunk, so it still has a
+                    //      dangling reference count handle that needs cleaning up. Since there's nothing left to
+                    //      do with this chunk, we can release it now.
+                    msgContent.release();
+                }
+            }
+        });
+    }
+
+    /**
+     * @return true if the stream has failed and the given content chunk released, false if the stream has *not*
+     * yet failed.
+     */
+    protected boolean releaseContentChunkIfStreamAlreadyFailed(
+        HttpContent content, ProxyRouterProcessingState proxyRouterState
+    ) {
+        if (proxyRouterState.isStreamingFailed()) {
+            // A previous chunk failed to stream, and we marked the proxyRouterState as having failed.
+            //      The previous chunk would have already caused the failure response to be sent to the
+            //      caller, therefore we don't need to do anything else for *this* chunk except release it.
+            content.release();
+            return true;
+        }
+
+        return false;
     }
 
     @Override
@@ -418,6 +467,7 @@ public class ProxyRouterEndpointExecutionHandler extends BaseInboundHandlerWithT
         private final RequestInfo<?> requestInfo;
         private final ProxyRouterProcessingState proxyRouterProcessingState;
         private boolean channelIsActive = true;
+        private boolean firstChunkSent = false;
         private boolean lastChunkSent = false;
         private boolean downstreamCallTimeSet = false;
 
@@ -486,6 +536,16 @@ public class ProxyRouterEndpointExecutionHandler extends BaseInboundHandlerWithT
             if (!channelIsActive)
                 return;
 
+            if (proxyRouterProcessingState.isStreamingFailed()) {
+                if (logger.isDebugEnabled()) {
+                    runnableWithTracingAndMdc(
+                        () -> logger.debug("ProxyRouter processing has failed - ignoring chunk from downstream call."),
+                        ctx
+                    ).run();
+                }
+                return;
+            }
+
             channelIsActive = executeOnlyIfChannelIsActive(ctx, "StreamingCallbackForCtx-messageReceived", () -> {
                 HttpProcessingState state = ChannelAttributes.getHttpProcessingStateForChannel(ctx).get();
 
@@ -509,7 +569,6 @@ public class ProxyRouterEndpointExecutionHandler extends BaseInboundHandlerWithT
                             //      HttpProcessingState so it can be streamed back to the client, and fire a pipeline
                             //      event to kick off sending the response back to the client.
                             ResponseInfo<?> responseInfo = createChunkedResponseInfoFromHttpResponse(httpResponse);
-                            state.setResponseInfo(responseInfo);
 
                             try {
                                 // Notify the circuit breaker of the response event.
@@ -522,9 +581,22 @@ public class ProxyRouterEndpointExecutionHandler extends BaseInboundHandlerWithT
                                 );
                             }
                             finally {
-                                // No need to retain the msg, we already grabbed everything we need from it and stuffed
-                                //      it into the ResponseInfo. Just send the appropriate OutboundMessage
-                                ctx.fireChannelRead(OutboundMessageSendHeadersChunkFromResponseInfo.INSTANCE);
+                                // We have to set the ResponseInfo on the state and fire the event while in the
+                                //      channel's EventLoop. Otherwise there could be a race condition with an error
+                                //      that was fired down the pipe that sets the ResponseInfo on the state first, then
+                                //      this comes along and replaces the ResponseInfo (or vice versa).
+                                EventExecutor executor = ctx.executor();
+                                if (executor.inEventLoop()) {
+                                    sendFirstChunkDownPipeline(state, responseInfo);
+                                }
+                                else {
+                                    executor.execute(new OneTimeTask() {
+                                        @Override
+                                        public void run() {
+                                            sendFirstChunkDownPipeline(state, responseInfo);
+                                        }
+                                    });
+                                }
                             }
                         },
                         ctx
@@ -536,17 +608,28 @@ public class ProxyRouterEndpointExecutionHandler extends BaseInboundHandlerWithT
 
                     // This time we do need to retain the msg since we don't want the data blasted away before we can
                     //      send it back to the user.
-                    ReferenceCountUtil.retain(msg);
+                    contentChunk.retain();
                     OutboundMessageSendContentChunk contentChunkToSend =
                         (contentChunk instanceof LastHttpContent)
                         ? new LastOutboundMessageSendLastContentChunk((LastHttpContent) contentChunk)
                         : new OutboundMessageSendContentChunk(contentChunk);
 
-                    ctx.fireChannelRead(contentChunkToSend);
-
                     if (contentChunk instanceof LastHttpContent) {
                         lastChunkSent = true;
                         setDownstreamCallTimeOnRequestAttributesIfNotAlreadyDone();
+                    }
+
+                    EventExecutor executor = ctx.executor();
+                    if (executor.inEventLoop()) {
+                        sendContentChunkDownPipeline(contentChunk, contentChunkToSend);
+                    }
+                    else {
+                        executor.execute(new OneTimeTask() {
+                            @Override
+                            public void run() {
+                                sendContentChunkDownPipeline(contentChunk, contentChunkToSend);
+                            }
+                        });
                     }
                 }
                 else {
@@ -558,10 +641,71 @@ public class ProxyRouterEndpointExecutionHandler extends BaseInboundHandlerWithT
             });
         }
 
+        protected void sendFirstChunkDownPipeline(HttpProcessingState state, ResponseInfo<?> responseInfo) {
+            if (state.isRequestHandled()) {
+                runnableWithTracingAndMdc(
+                    () -> logger.warn("The request has already been handled, likely due to an error, so the downstream "
+                                      + "call's response will be ignored."),
+                    ctx
+                ).run();
+                proxyRouterProcessingState.setStreamingFailed();
+                proxyRouterProcessingState.triggerStreamingChannelErrorForChunks(
+                    new RuntimeException("Request already handled.")
+                );
+            }
+            else {
+                state.setResponseInfo(responseInfo);
+                // No need to retain the msg, we already grabbed everything we need from it and stuffed it into the
+                //      ResponseInfo. Just send the appropriate OutboundMessage.
+                firstChunkSent = true;
+                ctx.fireChannelRead(OutboundMessageSendHeadersChunkFromResponseInfo.INSTANCE);
+            }
+        }
+
+        protected void sendContentChunkDownPipeline(HttpContent contentChunk,
+                                                    OutboundMessageSendContentChunk contentChunkToSend) {
+            if (proxyRouterProcessingState.isStreamingFailed()) {
+                runnableWithTracingAndMdc(
+                    () -> logger.warn("ProxyRouter processing has failed. Ignoring content chunk from "
+                                      + "downstream call."),
+                    ctx
+                ).run();
+                // Since this won't be written and flushed down the channel we have to release the message
+                //      here to avoid a memory leak.
+                contentChunk.release();
+            }
+            else
+                ctx.fireChannelRead(contentChunkToSend);
+        }
+
         @Override
         public void unrecoverableErrorOccurred(Throwable error) {
+            // Mark the downstream call as having failed on the proxy/router state so it stops trying to send data
+            //      downstream.
+            proxyRouterProcessingState.setStreamingFailed();
+            // Notify the proxy/router state of the error to trigger unwinding any backed-up chunks. This may do
+            //      nothing if the chunk streaming had already started, but that's ok. The important thing is that the
+            //      CompletableFuture controlling the chunk stream is started *at some point* so that chunk resources
+            //      can be released.
+            proxyRouterProcessingState.triggerStreamingChannelErrorForChunks(error);
+
             setDownstreamCallTimeOnRequestAttributesIfNotAlreadyDone();
 
+            EventExecutor executor = ctx.executor();
+            if (executor.inEventLoop()) {
+                sendUnrecoverableErrorDownPipeline(error);
+            }
+            else {
+                executor.execute(new OneTimeTask() {
+                    @Override
+                    public void run() {
+                        sendUnrecoverableErrorDownPipeline(error);
+                    }
+                });
+            }
+        }
+
+        protected void sendUnrecoverableErrorDownPipeline(Throwable error) {
             if (!channelIsActive)
                 return;
 
@@ -573,7 +717,9 @@ public class ProxyRouterEndpointExecutionHandler extends BaseInboundHandlerWithT
                         originalThreadInfo = AsyncNettyHelper.linkTracingAndMdcToCurrentThread(ctx);
 
                         HttpProcessingState state = ChannelAttributes.getHttpProcessingStateForChannel(ctx).get();
-                        if ((state != null && state.isResponseSendingLastChunkSent()) || lastChunkSent) {
+                        boolean stateResponseSendingStarted = state != null && state.isResponseSendingStarted();
+                        boolean stateResponseSendingLastChunkSent = state != null && state.isResponseSendingLastChunkSent();
+                        if (lastChunkSent || stateResponseSendingLastChunkSent) {
                             // A full response has already been sent to the user, so there's no point in firing an error
                             //      down the pipeline. This is likely a secondary symptom type error, so we'll log a
                             //      little info about it for debugging purposes but otherwise ignore it - no circuit
@@ -581,11 +727,25 @@ public class ProxyRouterEndpointExecutionHandler extends BaseInboundHandlerWithT
                             //      user and we don't want double counting.
                             logger.warn(
                                 "A secondary exception occurred after the response had already been sent to the user. "
-                                + "Not necessarily anything to worry about but in case it helps debugging the exception "
-                                + "was: {}", error.toString()
+                                + "Not necessarily anything to worry about but in case it helps debugging: "
+                                + "secondary_exception=\"{}\"", error.toString()
                             );
                         }
+                        else if (firstChunkSent || stateResponseSendingStarted) {
+                            // A partial response has been sent to the user, but something broke on the downstream call
+                            //      before the full response was sent.
+                            logger.warn(
+                                "The downstream system failed with an unrecoverable error after a partial response was "
+                                + "sent to the original caller. The downstream system will not be sending any more "
+                                + "data so the caller will be left with an incomplete response. "
+                                + "downstream_unrecoverable_error=\"{}\"", error.toString()
+                            );
+                            // Nothing we can do - this channel is unrecoverable, so close it.
+                            ctx.close();
+                        }
                         else {
+                            // The caller has not received any response yet, so we can send this error down the pipeline
+                            //      to be translated into an appropriate error response.
                             try {
                                 // Notify the circuit breaker of the error
                                 circuitBreakerManualModeTask.ifPresent(cb -> cb.handleException(error));

--- a/riposte-core/src/main/java/com/nike/riposte/server/handler/RequestFilterHandler.java
+++ b/riposte-core/src/main/java/com/nike/riposte/server/handler/RequestFilterHandler.java
@@ -22,7 +22,6 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.LastHttpContent;
-import io.netty.util.ReferenceCountUtil;
 
 /**
  * Handler for executing the request filtering side of the {@link RequestAndResponseFilter}s associated with this
@@ -85,13 +84,6 @@ public class RequestFilterHandler extends BaseInboundHandlerWithTracingAndMdcSup
 
                             state.setRequestInfo(currentReqInfo);
                             state.setResponseInfo(responseInfo);
-
-                            // We're done with the message since we're short circuiting. Release it (if the RequestInfo
-                            //      object is collecting chunks in order to build the raw content string then it will
-                            //      have retain()-ed the message already and this release won't cause the msg's
-                            //      reference count to fall below 1, but from the pipeline's point of view we're done
-                            //      with this message so we call release).
-                            ReferenceCountUtil.release(msg);
 
                             // Fire the short-circuit event that will get the desired response info sent to the caller.
                             ctx.fireChannelRead(LastOutboundMessageSendFullResponseInfo.INSTANCE);

--- a/riposte-core/src/main/java/com/nike/riposte/server/http/ProxyRouterProcessingState.java
+++ b/riposte-core/src/main/java/com/nike/riposte/server/http/ProxyRouterProcessingState.java
@@ -20,6 +20,7 @@ public class ProxyRouterProcessingState implements ProcessingState {
     private CompletableFuture<StreamingAsyncHttpClient.StreamingChannel> firstChunkCF;
     private CompletableFuture<StreamingAsyncHttpClient.StreamingChannel> latestChunkCF;
     private long streamingStartTimeNanos;
+    private boolean streamingFailed;
 
     public ProxyRouterProcessingState() {
         // Default constructor - do nothing
@@ -31,6 +32,7 @@ public class ProxyRouterProcessingState implements ProcessingState {
         firstChunkCF = null;
         latestChunkCF = null;
         streamingStartTimeNanos = 0;
+        streamingFailed = false;
     }
 
     public CompletableFuture<StreamingAsyncHttpClient.StreamingChannel> getStreamingChannelCompletableFuture() {
@@ -80,5 +82,13 @@ public class ProxyRouterProcessingState implements ProcessingState {
 
     public long getStreamingStartTimeNanos() {
         return streamingStartTimeNanos;
+    }
+
+    public boolean isStreamingFailed() {
+        return streamingFailed;
+    }
+
+    public void setStreamingFailed() {
+        this.streamingFailed = true;
     }
 }

--- a/riposte-core/src/test/java/com/nike/riposte/client/asynchttp/netty/StreamingAsyncHttpClientTest.java
+++ b/riposte-core/src/test/java/com/nike/riposte/client/asynchttp/netty/StreamingAsyncHttpClientTest.java
@@ -2,108 +2,413 @@ package com.nike.riposte.client.asynchttp.netty;
 
 import com.nike.riposte.client.asynchttp.netty.StreamingAsyncHttpClient.ObjectHolder;
 import com.nike.riposte.client.asynchttp.netty.StreamingAsyncHttpClient.StreamingChannel;
+import com.nike.wingtips.Span;
+
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 
+import java.util.Deque;
+import java.util.Map;
+
+import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.EventLoop;
 import io.netty.channel.pool.ChannelPool;
 import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.Attribute;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.GenericFutureListener;
 
 import static com.nike.riposte.client.asynchttp.netty.StreamingAsyncHttpClient.CHANNEL_IS_BROKEN_ATTR;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
 /**
  * Tests the functionality of {@link StreamingAsyncHttpClient}.
  *
  * @author Nic Munroe
  */
+@RunWith(DataProviderRunner.class)
 public class StreamingAsyncHttpClientTest {
 
     private Channel channelMock;
     private ChannelPool channelPoolMock;
+    private EventLoop eventLoopMock;
     private ObjectHolder<Boolean> callActiveHolder;
-    private StreamingChannel streamingChannel;
+    private ObjectHolder<Boolean> downstreamLastChunkSentHolder;
+    private StreamingChannel streamingChannelSpy;
     private HttpContent contentChunkMock;
-    private ChannelFuture streamChunkChannelFutureMock;
+    private ChannelFuture writeAndFlushChannelFutureMock;
 
     private Attribute<Boolean> channelIsBrokenAttrMock;
+
+    private ChannelPromise streamChunkChannelPromiseMock;
+
+    private ChannelFuture failedFutureMock;
 
     @Before
     public void beforeMethod() {
         channelMock = mock(Channel.class);
         channelPoolMock = mock(ChannelPool.class);
+        eventLoopMock = mock(EventLoop.class);
 
         contentChunkMock = mock(HttpContent.class);
 
         callActiveHolder = new ObjectHolder<>();
         callActiveHolder.heldObject = true;
 
-        streamingChannel = new StreamingChannel(channelMock, channelPoolMock, callActiveHolder);
+        downstreamLastChunkSentHolder = new ObjectHolder<>();
+        downstreamLastChunkSentHolder.heldObject = false;
 
-        streamChunkChannelFutureMock = mock(ChannelFuture.class);
+        streamingChannelSpy = spy(new StreamingChannel(channelMock, channelPoolMock, callActiveHolder,
+                                                       downstreamLastChunkSentHolder, null, null));
 
-        doReturn(streamChunkChannelFutureMock).when(channelMock).writeAndFlush(contentChunkMock);
+        writeAndFlushChannelFutureMock = mock(ChannelFuture.class);
+
+        doReturn(eventLoopMock).when(channelMock).eventLoop();
+
+        doReturn(writeAndFlushChannelFutureMock).when(channelMock).writeAndFlush(contentChunkMock);
 
         channelIsBrokenAttrMock = mock(Attribute.class);
         doReturn(channelIsBrokenAttrMock).when(channelMock).attr(CHANNEL_IS_BROKEN_ATTR);
+
+        streamChunkChannelPromiseMock = mock(ChannelPromise.class);
+        doReturn(streamChunkChannelPromiseMock).when(channelMock).newPromise();
+
+        failedFutureMock = mock(ChannelFuture.class);
+        doReturn(failedFutureMock).when(channelMock).newFailedFuture(any(Throwable.class));
     }
 
     @Test
-    public void StreamingChannel_streamChunk_works_as_expected_for_normal_case() {
+    public void constructor_sets_fields_as_expected() {
+        // given
+        Deque<Span> spanStackMock = mock(Deque.class);
+        Map<String, String> mdcInfoMock = mock(Map.class);
+
         // when
-        ChannelFuture result = streamingChannel.streamChunk(contentChunkMock);
+        StreamingChannel sc = new StreamingChannel(
+            channelMock, channelPoolMock, callActiveHolder, downstreamLastChunkSentHolder, spanStackMock, mdcInfoMock
+        );
 
         // then
-        verify(channelMock).writeAndFlush(contentChunkMock);
-        assertThat(result).isSameAs(streamChunkChannelFutureMock);
+        assertThat(sc.channel).isSameAs(channelMock);
+        assertThat(sc.getChannel()).isSameAs(sc.channel);
+        assertThat(sc.pool).isSameAs(channelPoolMock);
+        assertThat(sc.callActiveHolder).isSameAs(callActiveHolder);
+        assertThat(sc.downstreamLastChunkSentHolder).isSameAs(downstreamLastChunkSentHolder);
+        assertThat(sc.distributedTracingSpanStack).isSameAs(spanStackMock);
+        assertThat(sc.distributedTracingMdcInfo).isSameAs(mdcInfoMock);
     }
 
     @Test
-    public void StreamingChannel_streamChunk_works_as_expected_when_closeChannelDueToUnrecoverableError_was_called_previously() {
+    public void StreamingChannel_streamChunk_sets_up_task_in_event_loop_to_call_doStreamChunk_and_adds_listener_to_complete_promise()
+        throws Exception {
         // given
-        ChannelFuture failedChannelFutureMock = mock(ChannelFuture.class);
-        doReturn(failedChannelFutureMock).when(channelMock).newFailedFuture(any(Throwable.class));
-        streamingChannel.closeChannelDueToUnrecoverableError();
+        ChannelFuture doStreamChunkFutureMock = mock(ChannelFuture.class);
+        doReturn(doStreamChunkFutureMock).when(streamingChannelSpy).doStreamChunk(any(HttpContent.class));
 
         // when
-        ChannelFuture result = streamingChannel.streamChunk(contentChunkMock);
+        ChannelFuture result = streamingChannelSpy.streamChunk(contentChunkMock);
+
+        // then
+        assertThat(result).isSameAs(streamChunkChannelPromiseMock);
+        verifyZeroInteractions(streamChunkChannelPromiseMock); // not yet completed
+        ArgumentCaptor<Runnable> taskCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(eventLoopMock).execute(taskCaptor.capture());
+        Runnable task = taskCaptor.getValue();
+
+        // and given
+        verify(streamingChannelSpy, never()).doStreamChunk(any(HttpContent.class)); // not yet called
+
+        // when
+        task.run();
+
+        // then
+        verify(streamingChannelSpy).doStreamChunk(contentChunkMock);
+        ArgumentCaptor<GenericFutureListener> listenerCaptor = ArgumentCaptor.forClass(GenericFutureListener.class);
+        verify(doStreamChunkFutureMock).addListener(listenerCaptor.capture());
+        GenericFutureListener listener = listenerCaptor.getValue();
+        assertThat(listener).isNotNull();
+
+        // and when
+        listener.operationComplete(getFutureForCase(true, false, null));
+
+        // then
+        verify(streamChunkChannelPromiseMock).cancel(true);
+        verifyNoMoreInteractions(streamChunkChannelPromiseMock);
+
+        // and when
+        listener.operationComplete(getFutureForCase(false, true, null));
+
+        // then
+        verify(streamChunkChannelPromiseMock).setSuccess();
+        verifyNoMoreInteractions(streamChunkChannelPromiseMock);
+
+        // and when
+        Throwable normalFutureFailure = new RuntimeException("normal future failure");
+        listener.operationComplete(getFutureForCase(false, false, normalFutureFailure));
+
+        // then
+        verify(streamChunkChannelPromiseMock).setFailure(normalFutureFailure);
+        verifyNoMoreInteractions(streamChunkChannelPromiseMock);
+
+        // and when
+        reset(streamChunkChannelPromiseMock);
+        listener.operationComplete(getFutureForCase(false, false, null));
+
+        // then
+        ArgumentCaptor<Throwable> throwableCaptor = ArgumentCaptor.forClass(Throwable.class);
+        verify(streamChunkChannelPromiseMock).setFailure(throwableCaptor.capture());
+        assertThat(throwableCaptor.getValue()).hasMessage("Received ChannelFuture that was in an impossible state");
+        verifyNoMoreInteractions(streamChunkChannelPromiseMock);
+    }
+
+    private Future getFutureForCase(boolean isCanceled, boolean isSuccess, Throwable failureCause) {
+        Future futureMock = mock(Future.class);
+        doReturn(isCanceled).when(futureMock).isCancelled();
+        doReturn(isSuccess).when(futureMock).isSuccess();
+        doReturn(failureCause).when(futureMock).cause();
+        return futureMock;
+    }
+
+    @Test
+    public void StreamingChannel_streamChunk_fails_promise_with_unexpected_exception() {
+        // given
+        Throwable crazyEx = new RuntimeException("kaboom");
+        doThrow(crazyEx).when(eventLoopMock).execute(any(Runnable.class));
+
+        // when
+        ChannelFuture result = streamingChannelSpy.streamChunk(contentChunkMock);
+
+        // then
+        verifyFailedChannelFuture(result, "StreamingChannel.streamChunk() threw an exception", crazyEx);
+    }
+
+    private void verifyFailedChannelFuture(ChannelFuture result,
+                                           String expectedExceptionMessagePrefix,
+                                           Throwable expectedExCause) {
+        assertThat(result).isSameAs(failedFutureMock);
+        ArgumentCaptor<Throwable> exCaptor = ArgumentCaptor.forClass(Throwable.class);
+        verify(channelMock).newFailedFuture(exCaptor.capture());
+        Throwable exThatFailedTheFuture = exCaptor.getValue();
+        assertThat(exThatFailedTheFuture).hasMessageStartingWith(expectedExceptionMessagePrefix);
+        if (expectedExCause != null)
+            assertThat(exThatFailedTheFuture).hasCause(expectedExCause);
+    }
+
+    @Test
+    public void StreamingChannel_doStreamChunk_works_as_expected_when_last_chunk_already_sent_downstream_and_incoming_chunk_is_empty_last_chunk() {
+        // given
+        streamingChannelSpy.downstreamLastChunkSentHolder.heldObject = true;
+
+        LastHttpContent contentChunkMock = mock(LastHttpContent.class);
+        ByteBuf contentByteBufMock = mock(ByteBuf.class);
+        doReturn(contentByteBufMock).when(contentChunkMock).content();
+        doReturn(0).when(contentByteBufMock).readableBytes();
+
+        ChannelFuture successFutureMock = mock(ChannelFuture.class);
+        doReturn(successFutureMock).when(channelMock).newSucceededFuture();
+
+        // when
+        ChannelFuture result = streamingChannelSpy.doStreamChunk(contentChunkMock);
 
         // then
         verify(channelMock, never()).writeAndFlush(any(Object.class));
-        assertThat(result).isSameAs(failedChannelFutureMock);
         verify(contentChunkMock).release();
+        verify(channelMock).newSucceededFuture();
+        assertThat(result).isSameAs(successFutureMock);
+    }
 
-        ArgumentCaptor<Throwable> exceptionCaptor = ArgumentCaptor.forClass(Throwable.class);
-        verify(channelMock).newFailedFuture(exceptionCaptor.capture());
-        assertThat(exceptionCaptor.getValue())
-            .hasMessage("Unable to stream chunks downstream - "
-                        + "the channel was closed previously due to an unrecoverable error"
-            );
+    @DataProvider(value = {
+        "false  |   0",
+        "true   |   42"
+    }, splitBy = "\\|")
+    @Test
+    public void StreamingChannel_doStreamChunk_works_as_expected_when_last_chunk_already_sent_downstream_and_incoming_chunk_does_not_match_requirements(
+        boolean chunkIsLastChunk, int readableBytes
+    ) {
+        // given
+        streamingChannelSpy.downstreamLastChunkSentHolder.heldObject = true;
+        streamingChannelSpy.callActiveHolder.heldObject = true;
+        streamingChannelSpy.channelClosedDueToUnrecoverableError = false;
+
+        HttpContent contentChunkMock = (chunkIsLastChunk) ? mock(LastHttpContent.class) : mock(HttpContent.class);
+        ByteBuf contentByteBufMock = mock(ByteBuf.class);
+        doReturn(contentByteBufMock).when(contentChunkMock).content();
+        doReturn(readableBytes).when(contentByteBufMock).readableBytes();
+
+        doReturn(writeAndFlushChannelFutureMock).when(channelMock).writeAndFlush(contentChunkMock);
+
+        // when
+        ChannelFuture result = streamingChannelSpy.doStreamChunk(contentChunkMock);
+
+        // then
+        verify(channelMock).writeAndFlush(contentChunkMock);
+        assertThat(result).isSameAs(writeAndFlushChannelFutureMock);
     }
 
     @Test
-    public void StreamingChannel_closeChannelDueToUnrecoverableError_works_as_expected() {
+    public void StreamingChannel_doStreamChunk_works_as_expected_when_downstream_call_is_not_active() {
         // given
-        assertThat(streamingChannel.channelClosedDueToUnrecoverableError).isFalse();
-        assertThat(streamingChannel.callActiveHolder.heldObject).isTrue();
+        streamingChannelSpy.callActiveHolder.heldObject = false;
 
         // when
-        streamingChannel.closeChannelDueToUnrecoverableError();
+        ChannelFuture result = streamingChannelSpy.doStreamChunk(contentChunkMock);
 
         // then
-        assertThat(streamingChannel.channelClosedDueToUnrecoverableError).isTrue();
-        verify(channelIsBrokenAttrMock).set(true);
-        verifyChannelReleasedBackToPool(streamingChannel.callActiveHolder, channelPoolMock, channelMock);
-        verify(channelMock).close();
+        verify(channelMock, never()).writeAndFlush(any(Object.class));
+        verify(contentChunkMock).release();
+
+        verifyFailedChannelFuture(
+            result, "Unable to stream chunk - downstream call is no longer active.", null
+        );
+    }
+
+    @Test
+    public void StreamingChannel_doStreamChunk_works_as_expected_when_closeChannelDueToUnrecoverableError_was_called_previously() {
+        // given
+        streamingChannelSpy.channelClosedDueToUnrecoverableError = true;
+
+        // when
+        ChannelFuture result = streamingChannelSpy.doStreamChunk(contentChunkMock);
+
+        // then
+        verify(channelMock, never()).writeAndFlush(any(Object.class));
+        verify(contentChunkMock).release();
+
+        verifyFailedChannelFuture(
+            result, "Unable to stream chunks downstream - the channel was closed previously due to an unrecoverable error", null
+        );
+    }
+
+    @Test
+    public void StreamingChannel_doStreamChunk_works_as_expected_when_crazy_exception_is_thrown() {
+        // given
+        Throwable crazyEx = new RuntimeException("kaboom");
+        doThrow(crazyEx).when(channelMock).writeAndFlush(any(Object.class));
+
+        // when
+        ChannelFuture result = streamingChannelSpy.doStreamChunk(contentChunkMock);
+
+        // then
+        verify(channelMock).writeAndFlush(any(Object.class));
+        verify(contentChunkMock, never()).release();
+
+        verifyFailedChannelFuture(
+            result, "StreamingChannel.doStreamChunk() threw an exception", crazyEx
+        );
+    }
+
+    @Test
+    public void StreamingChannel_closeChannelDueToUnrecoverableError_calls_the_do_method_and_sets_field_to_true_when_not_closed_and_call_active() {
+        // given
+        Throwable unrecoverableError = new RuntimeException("kaboom");
+        streamingChannelSpy.channelClosedDueToUnrecoverableError = false;
+        streamingChannelSpy.callActiveHolder.heldObject = true;
+
+        // when
+        streamingChannelSpy.closeChannelDueToUnrecoverableError(unrecoverableError);
+
+        // then
+        assertThat(streamingChannelSpy.channelClosedDueToUnrecoverableError).isTrue();
+        ArgumentCaptor<Runnable> taskCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(eventLoopMock).execute(taskCaptor.capture());
+        Runnable task = taskCaptor.getValue();
+        assertThat(task).isNotNull();
+
+        // and given
+        verify(streamingChannelSpy, never()).doCloseChannelDueToUnrecoverableError(any(Throwable.class));
+
+        // when
+        task.run();
+
+        // then
+        verify(streamingChannelSpy).doCloseChannelDueToUnrecoverableError(unrecoverableError);
+    }
+
+    @DataProvider(value = {
+        "true   |   true",
+        "false  |   false",
+        "true   |   false"
+    }, splitBy = "\\|")
+    @Test
+    public void StreamingChannel_closeChannelDueToUnrecoverableError_sets_field_to_true_but_otherwise_does_nothing_if_already_closed_or_call_inactive(
+        boolean alreadyClosed, boolean callActive
+    ) {
+        // given
+        Throwable unrecoverableError = new RuntimeException("kaboom");
+        streamingChannelSpy.channelClosedDueToUnrecoverableError = alreadyClosed;
+        streamingChannelSpy.callActiveHolder.heldObject = callActive;
+
+        // when
+        streamingChannelSpy.closeChannelDueToUnrecoverableError(unrecoverableError);
+
+        // then
+        assertThat(streamingChannelSpy.channelClosedDueToUnrecoverableError).isTrue();
+        verifyZeroInteractions(channelMock);
+    }
+
+    @Test
+    public void StreamingChannel_closeChannelDueToUnrecoverableError_sets_field_to_true_even_if_crazy_exception_occurs() {
+        // given
+        streamingChannelSpy.channelClosedDueToUnrecoverableError = false;
+        streamingChannelSpy.callActiveHolder.heldObject = true;
+        Throwable crazyEx = new RuntimeException("kaboom");
+        doThrow(crazyEx).when(channelMock).eventLoop();
+
+        // when
+        Throwable caughtEx = catchThrowable(
+            () -> streamingChannelSpy.closeChannelDueToUnrecoverableError(new RuntimeException("some other error"))
+        );
+
+        // then
+        assertThat(caughtEx).isSameAs(crazyEx);
+        assertThat(streamingChannelSpy.channelClosedDueToUnrecoverableError).isTrue();
+    }
+
+    @DataProvider(value = {
+        "true",
+        "false"
+    })
+    @Test
+    public void StreamingChannel_doCloseChannelDueToUnrecoverableError_works_as_expected(boolean callActive) {
+        // given
+        streamingChannelSpy.callActiveHolder.heldObject = callActive;
+        Throwable unrecoverableError = new RuntimeException("kaboom");
+
+        // when
+        streamingChannelSpy.doCloseChannelDueToUnrecoverableError(unrecoverableError);
+
+        // then
+        if (callActive) {
+            verify(channelIsBrokenAttrMock).set(true);
+            verifyChannelReleasedBackToPool(streamingChannelSpy.callActiveHolder, channelPoolMock, channelMock);
+            verify(channelMock).close();
+        }
+        else {
+            verify(channelIsBrokenAttrMock, never()).set(anyBoolean());
+            verify(channelMock, never()).close();
+        }
+
     }
 
     private void verifyChannelReleasedBackToPool(ObjectHolder<Boolean> callActiveHolder,

--- a/riposte-core/src/test/java/com/nike/riposte/client/asynchttp/netty/StreamingAsyncHttpClientTest.java
+++ b/riposte-core/src/test/java/com/nike/riposte/client/asynchttp/netty/StreamingAsyncHttpClientTest.java
@@ -1,0 +1,116 @@
+package com.nike.riposte.client.asynchttp.netty;
+
+import com.nike.riposte.client.asynchttp.netty.StreamingAsyncHttpClient.ObjectHolder;
+import com.nike.riposte.client.asynchttp.netty.StreamingAsyncHttpClient.StreamingChannel;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.pool.ChannelPool;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.util.Attribute;
+
+import static com.nike.riposte.client.asynchttp.netty.StreamingAsyncHttpClient.CHANNEL_IS_BROKEN_ATTR;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests the functionality of {@link StreamingAsyncHttpClient}.
+ *
+ * @author Nic Munroe
+ */
+public class StreamingAsyncHttpClientTest {
+
+    private Channel channelMock;
+    private ChannelPool channelPoolMock;
+    private ObjectHolder<Boolean> callActiveHolder;
+    private StreamingChannel streamingChannel;
+    private HttpContent contentChunkMock;
+    private ChannelFuture streamChunkChannelFutureMock;
+
+    private Attribute<Boolean> channelIsBrokenAttrMock;
+
+    @Before
+    public void beforeMethod() {
+        channelMock = mock(Channel.class);
+        channelPoolMock = mock(ChannelPool.class);
+
+        contentChunkMock = mock(HttpContent.class);
+
+        callActiveHolder = new ObjectHolder<>();
+        callActiveHolder.heldObject = true;
+
+        streamingChannel = new StreamingChannel(channelMock, channelPoolMock, callActiveHolder);
+
+        streamChunkChannelFutureMock = mock(ChannelFuture.class);
+
+        doReturn(streamChunkChannelFutureMock).when(channelMock).writeAndFlush(contentChunkMock);
+
+        channelIsBrokenAttrMock = mock(Attribute.class);
+        doReturn(channelIsBrokenAttrMock).when(channelMock).attr(CHANNEL_IS_BROKEN_ATTR);
+    }
+
+    @Test
+    public void StreamingChannel_streamChunk_works_as_expected_for_normal_case() {
+        // when
+        ChannelFuture result = streamingChannel.streamChunk(contentChunkMock);
+
+        // then
+        verify(channelMock).writeAndFlush(contentChunkMock);
+        assertThat(result).isSameAs(streamChunkChannelFutureMock);
+    }
+
+    @Test
+    public void StreamingChannel_streamChunk_works_as_expected_when_closeChannelDueToUnrecoverableError_was_called_previously() {
+        // given
+        ChannelFuture failedChannelFutureMock = mock(ChannelFuture.class);
+        doReturn(failedChannelFutureMock).when(channelMock).newFailedFuture(any(Throwable.class));
+        streamingChannel.closeChannelDueToUnrecoverableError();
+
+        // when
+        ChannelFuture result = streamingChannel.streamChunk(contentChunkMock);
+
+        // then
+        verify(channelMock, never()).writeAndFlush(any(Object.class));
+        assertThat(result).isSameAs(failedChannelFutureMock);
+        verify(contentChunkMock).release();
+
+        ArgumentCaptor<Throwable> exceptionCaptor = ArgumentCaptor.forClass(Throwable.class);
+        verify(channelMock).newFailedFuture(exceptionCaptor.capture());
+        assertThat(exceptionCaptor.getValue())
+            .hasMessage("Unable to stream chunks downstream - "
+                        + "the channel was closed previously due to an unrecoverable error"
+            );
+    }
+
+    @Test
+    public void StreamingChannel_closeChannelDueToUnrecoverableError_works_as_expected() {
+        // given
+        assertThat(streamingChannel.channelClosedDueToUnrecoverableError).isFalse();
+        assertThat(streamingChannel.callActiveHolder.heldObject).isTrue();
+
+        // when
+        streamingChannel.closeChannelDueToUnrecoverableError();
+
+        // then
+        assertThat(streamingChannel.channelClosedDueToUnrecoverableError).isTrue();
+        verify(channelIsBrokenAttrMock).set(true);
+        verifyChannelReleasedBackToPool(streamingChannel.callActiveHolder, channelPoolMock, channelMock);
+        verify(channelMock).close();
+    }
+
+    private void verifyChannelReleasedBackToPool(ObjectHolder<Boolean> callActiveHolder,
+                                                 ChannelPool theChannelPoolMock,
+                                                 Channel theChannelMock) {
+        assertThat(callActiveHolder.heldObject).isFalse();
+        verify(theChannelPoolMock).release(theChannelMock);
+    }
+
+}

--- a/riposte-core/src/test/java/com/nike/riposte/server/handler/ChannelPipelineFinalizerHandlerTest.java
+++ b/riposte-core/src/test/java/com/nike/riposte/server/handler/ChannelPipelineFinalizerHandlerTest.java
@@ -11,16 +11,23 @@ import com.nike.riposte.server.http.RequestInfo;
 import com.nike.riposte.server.http.ResponseInfo;
 import com.nike.riposte.server.http.ResponseSender;
 import com.nike.riposte.server.metrics.ServerMetricsEvent;
+import com.nike.wingtips.Span;
+import com.nike.wingtips.Tracer;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.internal.util.reflection.Whitebox;
+import org.slf4j.Logger;
+
+import java.util.Deque;
+import java.util.LinkedList;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -41,11 +48,13 @@ import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
 /**
  * Tests the functionality of {@link com.nike.riposte.server.handler.ChannelPipelineFinalizerHandler}
@@ -63,6 +72,7 @@ public class ChannelPipelineFinalizerHandlerTest {
     private Attribute<HttpProcessingState> stateAttributeMock;
     private Attribute<ProxyRouterProcessingState> proxyRouterProcessingStateAttributeMock;
     private HttpProcessingState state;
+    private ProxyRouterProcessingState proxyRouterStateMock;
     private RequestInfo<?> requestInfoMock;
     private ResponseInfo<?> responseInfoMock;
     private final long workerChannelIdleTimeoutMillis = 4242;
@@ -79,18 +89,23 @@ public class ChannelPipelineFinalizerHandlerTest {
         stateAttributeMock = mock(Attribute.class);
         proxyRouterProcessingStateAttributeMock = mock(Attribute.class);
         state = new HttpProcessingState();
+        proxyRouterStateMock = mock(ProxyRouterProcessingState.class);
         responseInfoMock = mock(ResponseInfo.class);
         requestInfoMock = mock(RequestInfo.class);
         doReturn(channelMock).when(ctxMock).channel();
         doReturn(pipelineMock).when(ctxMock).pipeline();
         doReturn(stateAttributeMock).when(channelMock).attr(ChannelAttributes.HTTP_PROCESSING_STATE_ATTRIBUTE_KEY);
         doReturn(state).when(stateAttributeMock).get();
+        doReturn(proxyRouterStateMock).when(proxyRouterProcessingStateAttributeMock).get();
         doReturn(proxyRouterProcessingStateAttributeMock).when(channelMock).attr(ChannelAttributes.PROXY_ROUTER_PROCESSING_STATE_ATTRIBUTE_KEY);
         doReturn(requestInfoMock).when(exceptionHandlingHandlerMock).getRequestInfo(any(HttpProcessingState.class), any(Object.class));
         doReturn(true).when(responseInfoMock).isResponseSendingStarted();
         doReturn(true).when(responseInfoMock).isResponseSendingLastChunkSent();
         state.setResponseInfo(responseInfoMock);
         state.setRequestInfo(requestInfoMock);
+
+        if (Tracer.getInstance().getCurrentSpan() != null)
+            Tracer.getInstance().completeRequestSpan();
     }
 
     @Test
@@ -189,6 +204,7 @@ public class ChannelPipelineFinalizerHandlerTest {
         doReturn(stateSpy).when(stateAttributeMock).get();
         ChannelFuture responseWriteFutureResult = mock(ChannelFuture.class);
         doReturn(true).when(responseWriteFutureResult).isSuccess();
+        Assertions.assertThat(stateSpy.isRequestMetricsRecordedOrScheduled()).isFalse();
 
         // when
         handler.finalizeChannelPipeline(ctxMock, null, stateSpy, null);
@@ -202,6 +218,7 @@ public class ChannelPipelineFinalizerHandlerTest {
 
         verify(metricsListenerMock).onEvent(eq(ServerMetricsEvent.RESPONSE_SENT), any(HttpProcessingState.class));
         verify(ctxMock).flush();
+        Assertions.assertThat(stateSpy.isRequestMetricsRecordedOrScheduled()).isTrue();
     }
 
     @Test
@@ -213,6 +230,7 @@ public class ChannelPipelineFinalizerHandlerTest {
         doReturn(stateSpy).when(stateAttributeMock).get();
         ChannelFuture responseWriteFutureResult = mock(ChannelFuture.class);
         doReturn(false).when(responseWriteFutureResult).isSuccess();
+        Assertions.assertThat(stateSpy.isRequestMetricsRecordedOrScheduled()).isFalse();
 
         // when
         handler.finalizeChannelPipeline(ctxMock, null, stateSpy, null);
@@ -226,6 +244,29 @@ public class ChannelPipelineFinalizerHandlerTest {
 
         verify(metricsListenerMock).onEvent(ServerMetricsEvent.RESPONSE_WRITE_FAILED, null);
         verify(ctxMock).flush();
+        Assertions.assertThat(stateSpy.isRequestMetricsRecordedOrScheduled()).isTrue();
+    }
+
+    @DataProvider(value = {
+        "true   |   false",
+        "false  |   true"
+    }, splitBy = "\\|")
+    @Test
+    public void finalizeChannelPipeline_should_not_call_metricsListener_if_metricsListener_is_null_or_metrics_already_scheduled(
+        boolean metricsListenerIsNull, boolean metricsAlreadyScheduled
+    ) throws Exception {
+        // given
+        if (metricsListenerIsNull)
+            Whitebox.setInternalState(handler, "metricsListener", null);
+
+        state.setRequestMetricsRecordedOrScheduled(metricsAlreadyScheduled);
+
+        // when
+        handler.finalizeChannelPipeline(ctxMock, null, state, null);
+
+        // then
+        verifyZeroInteractions(metricsListenerMock);
+        Assertions.assertThat(state.isRequestMetricsRecordedOrScheduled()).isEqualTo(metricsAlreadyScheduled);
     }
 
     @Test
@@ -272,20 +313,234 @@ public class ChannelPipelineFinalizerHandlerTest {
     }
 
     @DataProvider(value = {
-        "0",
-        "-42"
+        "0      |   false",
+        "-42    |   false",
+        "42     |   true"
     }, splitBy = "\\|")
     @Test
-    public void finalizeChannelPipeline_does_not_add_idle_channel_timeout_handler_to_pipeline_if_workerChannelIdleTimeoutMillis_is_not_greater_than_0(long timeoutVal)
-        throws JsonProcessingException {
+    public void finalizeChannelPipeline_does_not_add_idle_channel_timeout_handler_to_pipeline_if_workerChannelIdleTimeoutMillis_is_not_greater_than_0_or_idle_timeout_handler_already_exists(
+        long timeoutVal, boolean idleTimeoutHandlerAlreadyExists
+    ) throws JsonProcessingException {
         // given
         Whitebox.setInternalState(handler, "workerChannelIdleTimeoutMillis", timeoutVal);
         LastOutboundMessage msg = mock(LastOutboundMessage.class);
+        if (idleTimeoutHandlerAlreadyExists)
+            doReturn(mock(ChannelHandler.class)).when(pipelineMock).get(IDLE_CHANNEL_TIMEOUT_HANDLER_NAME);
 
         // when
         handler.finalizeChannelPipeline(ctxMock, msg, state, null);
 
         // then
         verify(pipelineMock, never()).addFirst(anyString(), anyObject());
+    }
+
+    @DataProvider(value = {
+        "false  |   true    |   false   |   true",
+        "true   |   true    |   false   |   false",
+        "false  |   false   |   false   |   false",
+        "false  |   true    |   true    |   false",
+    }, splitBy = "\\|")
+    @Test
+    public void finalizeChannelPipeline_should_close_channel_or_not_depending_on_error_and_state_of_request(
+        boolean errorIsNull, boolean responseSendingStarted, boolean responseSendingCompleted, boolean channelCloseIsExpected
+    ) throws JsonProcessingException {
+        // given
+        Throwable error = (errorIsNull) ? null : new RuntimeException("kaboom");
+        doReturn(responseSendingStarted).when(responseInfoMock).isResponseSendingStarted();
+        doReturn(responseSendingCompleted).when(responseInfoMock).isResponseSendingLastChunkSent();
+        if (responseSendingCompleted) {
+            state.setResponseWriterFinalChunkChannelFuture(mock(ChannelFuture.class));
+        }
+
+        // when
+        handler.finalizeChannelPipeline(ctxMock, null, state, error);
+
+        // then
+        if (channelCloseIsExpected)
+            verify(channelMock).close();
+        else
+            verify(channelMock, never()).close();
+    }
+
+    @DataProvider(value = {
+        "true   |   true",
+        "false  |   true",
+        "true   |   false",
+        "false  |   false"
+    }, splitBy = "\\|")
+    @Test
+    public void doChannelInactive_completes_releases_resources_and_completes_tracing_if_necessary(
+        boolean tracingAlreadyDone, boolean responseSendingCompleted
+    ) throws Exception {
+        // given
+        Span span = setupTracingForChannelInactive(tracingAlreadyDone);
+        doReturn(responseSendingCompleted).when(responseInfoMock).isResponseSendingLastChunkSent();
+        if (responseSendingCompleted) {
+            state.setResponseWriterFinalChunkChannelFuture(mock(ChannelFuture.class));
+        }
+
+        // when
+        PipelineContinuationBehavior result = handler.doChannelInactive(ctxMock);
+
+        // then
+        Assertions.assertThat(span.isCompleted()).isEqualTo(!tracingAlreadyDone);
+        Assertions.assertThat(state.isTraceCompletedOrScheduled()).isTrue();
+
+        verify(requestInfoMock).releaseAllResources();
+        verify(proxyRouterStateMock).setStreamingFailed();
+        verify(proxyRouterStateMock).triggerStreamingChannelErrorForChunks(any(Throwable.class));
+        Assertions.assertThat(result).isEqualTo(PipelineContinuationBehavior.CONTINUE);
+    }
+
+    private Span setupTracingForChannelInactive(boolean traceCompletedOrScheduled) {
+        state.setTraceCompletedOrScheduled(traceCompletedOrScheduled);
+        Span span = Span.newBuilder("fooSpan", Span.SpanPurpose.SERVER).build();
+        Assertions.assertThat(span.isCompleted()).isFalse();
+        Deque<Span> spanStack = new LinkedList<>();
+        spanStack.add(span);
+        state.setDistributedTraceStack(spanStack);
+
+        return span;
+    }
+
+    @DataProvider(value = {
+        "true   |   false",
+        "false  |   true",
+        "true   |   true"
+    }, splitBy = "\\|")
+    @Test
+    public void doChannelInactive_does_what_it_can_when_the_HttpProcessingState_or_ProxyRouterProcessingState_is_null(
+        boolean httpStateIsNull, boolean proxyRouterStateIsNull
+    ) throws Exception {
+        // given
+        if (httpStateIsNull)
+            doReturn(null).when(stateAttributeMock).get();
+
+        if (proxyRouterStateIsNull)
+            doReturn(null).when(proxyRouterProcessingStateAttributeMock).get();
+
+        Span span = setupTracingForChannelInactive(false);
+
+        // when
+        PipelineContinuationBehavior result = handler.doChannelInactive(ctxMock);
+
+        // then
+        if (httpStateIsNull)
+            Assertions.assertThat(span.isCompleted()).isFalse();
+        else
+            Assertions.assertThat(span.isCompleted()).isTrue();
+
+        if (httpStateIsNull)
+            verifyZeroInteractions(requestInfoMock);
+        else
+            verify(requestInfoMock).releaseAllResources();
+
+        if (proxyRouterStateIsNull)
+            verifyZeroInteractions(proxyRouterStateMock);
+        else {
+            verify(proxyRouterStateMock).setStreamingFailed();
+            verify(proxyRouterStateMock).triggerStreamingChannelErrorForChunks(any(Throwable.class));
+        }
+        
+        Assertions.assertThat(result).isEqualTo(PipelineContinuationBehavior.CONTINUE);
+    }
+
+    @DataProvider(value = {
+        "true   |   false",
+        "false  |   true",
+        "true   |   true"
+    }, splitBy = "\\|")
+    @Test
+    public void doChannelInactive_does_what_it_can_when_the_RequestInfo_or_ResponseInfo_is_null(
+        boolean requestInfoIsNull, boolean responseInfoIsNull
+    ) throws Exception {
+        // given
+        Span span = setupTracingForChannelInactive(false);
+
+        if (requestInfoIsNull)
+            state.setRequestInfo(null);
+
+        if (responseInfoIsNull)
+            state.setResponseInfo(null);
+
+        // when
+        PipelineContinuationBehavior result = handler.doChannelInactive(ctxMock);
+
+        // then
+        Assertions.assertThat(span.isCompleted()).isTrue();
+        Assertions.assertThat(state.isTraceCompletedOrScheduled()).isTrue();
+
+        if (requestInfoIsNull)
+            verifyZeroInteractions(requestInfoMock);
+        else
+            verify(requestInfoMock).releaseAllResources();
+        
+        verify(proxyRouterStateMock).setStreamingFailed();
+        verify(proxyRouterStateMock).triggerStreamingChannelErrorForChunks(any(Throwable.class));
+        Assertions.assertThat(result).isEqualTo(PipelineContinuationBehavior.CONTINUE);
+    }
+
+    @Test
+    public void doChannelInactive_does_not_try_to_recomplete_span_if_already_completed() throws Exception {
+        // given
+        Span span = setupTracingForChannelInactive(false);
+        Deque<Span> deque = new LinkedList<>();
+        deque.add(span);
+        Tracer.getInstance().registerWithThread(deque);
+        Tracer.getInstance().completeRequestSpan();
+        Assertions.assertThat(span.isCompleted()).isTrue();
+        long durationNanosBefore = span.getDurationNanos();
+
+        // when
+        PipelineContinuationBehavior result = handler.doChannelInactive(ctxMock);
+
+        // then
+        Assertions.assertThat(span.isCompleted()).isTrue(); // no change
+        Assertions.assertThat(span.getDurationNanos()).isEqualTo(durationNanosBefore);
+
+        verify(requestInfoMock).releaseAllResources();
+        verify(proxyRouterStateMock).setStreamingFailed();
+        verify(proxyRouterStateMock).triggerStreamingChannelErrorForChunks(any(Throwable.class));
+        Assertions.assertThat(result).isEqualTo(PipelineContinuationBehavior.CONTINUE);
+    }
+
+    @Test
+    public void doChannelInactive_does_not_explode_if_span_is_missing() throws Exception {
+        // given
+        Assertions.assertThat(state.getDistributedTraceStack()).isNull();
+
+        // when
+        PipelineContinuationBehavior result = handler.doChannelInactive(ctxMock);
+
+        // then
+        verify(requestInfoMock).releaseAllResources();
+        verify(proxyRouterStateMock).setStreamingFailed();
+        verify(proxyRouterStateMock).triggerStreamingChannelErrorForChunks(any(Throwable.class));
+        Assertions.assertThat(result).isEqualTo(PipelineContinuationBehavior.CONTINUE);
+    }
+    
+    @Test
+    public void doChannelInactive_does_not_explode_if_crazy_exception_occurs() throws Exception {
+        // given
+        doThrow(new RuntimeException("kaboom")).when(proxyRouterProcessingStateAttributeMock).get();
+
+        // when
+        PipelineContinuationBehavior result = handler.doChannelInactive(ctxMock);
+
+        // then
+        Assertions.assertThat(result).isEqualTo(PipelineContinuationBehavior.CONTINUE);
+    }
+
+    @Test
+    public void code_coverage_hoops() throws Exception {
+        // jump!
+
+        // doChannelInactive() does some debug logging if the logger has debug logging enabled.
+        Logger loggerMock = mock(Logger.class);
+        doReturn(true).when(loggerMock).isDebugEnabled();
+        Whitebox.setInternalState(handler, "logger", loggerMock);
+        handler.doChannelInactive(ctxMock);
+        doReturn(false).when(loggerMock).isDebugEnabled();
+        handler.doChannelInactive(ctxMock);
     }
 }

--- a/riposte-core/src/test/java/com/nike/riposte/server/handler/ChannelPipelineFinalizerHandlerTest.java
+++ b/riposte-core/src/test/java/com/nike/riposte/server/handler/ChannelPipelineFinalizerHandlerTest.java
@@ -532,6 +532,14 @@ public class ChannelPipelineFinalizerHandlerTest {
     }
 
     @Test
+    public void argsAreEligibleForLinkingAndUnlinkingDistributedTracingInfo_returns_false() {
+        // expect
+        Assertions.assertThat(
+            handler.argsAreEligibleForLinkingAndUnlinkingDistributedTracingInfo(null, null, null, null)
+        ).isFalse();
+    }
+
+    @Test
     public void code_coverage_hoops() throws Exception {
         // jump!
 

--- a/riposte-metrics-codahale/src/main/java/com/nike/riposte/metrics/codahale/CodahaleMetricsListener.java
+++ b/riposte-metrics-codahale/src/main/java/com/nike/riposte/metrics/codahale/CodahaleMetricsListener.java
@@ -270,7 +270,7 @@ public class CodahaleMetricsListener implements MetricsListener {
                 // Make sure HttpProcessingState, RequestInfo, and ResponseInfo are populated with the things we need.
                 RequestInfo<?> requestInfo = httpState.getRequestInfo();
                 if (requestInfo == null) {
-                    logger.error("Metrics Error: httpStatemgetRequestInfo() is null");
+                    logger.error("Metrics Error: httpState.getRequestInfo() is null");
                     return;
                 }
 

--- a/riposte-spi/src/main/java/com/nike/riposte/server/http/impl/RequestInfoImpl.java
+++ b/riposte-spi/src/main/java/com/nike/riposte/server/http/impl/RequestInfoImpl.java
@@ -390,7 +390,7 @@ public class RequestInfoImpl<T> implements RequestInfo<T>, RiposteInternalReques
     @Override
     public void contentChunksWillBeReleasedExternally() {
         this.contentChunksWillBeReleasedExternally = true;
-        // If we had somehow already pulled in some content chunks then can remove them from the contentChunks list,
+        // If we had somehow already pulled in some content chunks then we can remove them from the contentChunks list,
         //      however as per the javadocs for this method we should *not* release() them.
         if (contentChunks.size() > 0) {
             contentChunks.clear();

--- a/riposte-spi/src/main/java/com/nike/riposte/server/http/impl/RiposteInternalRequestInfo.java
+++ b/riposte-spi/src/main/java/com/nike/riposte/server/http/impl/RiposteInternalRequestInfo.java
@@ -1,0 +1,38 @@
+package com.nike.riposte.server.http.impl;
+
+import com.nike.riposte.server.http.RequestInfo;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.http.HttpContent;
+
+/**
+ * Interface that implementations of {@link RequestInfo} should also implement - this interface covers some
+ * under-the-hood stuff that implementations of {@link RequestInfo} need to support for Riposte internals to work
+ * correctly, but app developers shouldn't need to worry about (which is why we hide them here in a separate interface).
+ *
+ * @author Nic Munroe
+ */
+public interface RiposteInternalRequestInfo {
+
+    /**
+     * Indicates to this {@link RequestInfo} implementation that all content chunks will be handled externally, e.g.
+     * {@code ProxyRouterEndpoint}s where the content chunks are immediately released after being sent downstream
+     * to avoid pulling the full request into memory. In other words this should disable {@link
+     * RequestInfo#releaseContentChunks()} so that when that method is called it does *not* call {@link
+     * ByteBuf#release()} on any content chunks. This avoids releasing chunks too many times, thus causing reference
+     * counting bugs.
+     *
+     * <p>IMPORTANT NOTE: Implementations should continue to {@link ByteBuf#retain()} chunks as they are added via
+     * {@link RequestInfo#addContentChunk(HttpContent)}. This method only means they will be *released* externally,
+     * but {@link RequestInfo} is still expected to retain the chunks so that they aren't prematurely destroyed.
+     *
+     * <p>ALSO NOTE: Since content chunks may be released externally early (even before the last content chunk arrives
+     * from the original caller) {@link RequestInfo} must never allow {@link
+     * RequestInfo#isCompleteRequestWithAllChunks()} to be set to true and must never allow any of the content-related
+     * methods to return "real" values (e.g. all the {@code RequestInfo#get*Content()} methods should return null),
+     * *UNLESS* the full request has already arrived and the content already pulled into heap memory at which point no
+     * damage would be done by allowing those methods to continue to work.
+     */
+    void contentChunksWillBeReleasedExternally();
+
+}


### PR DESCRIPTION
This should fix the following:

* No more Netty ByteBuf reference counting memory leaks. If you saw any log messages that looked like `LEAK: ByteBuf.release() was not called before it's garbage-collected` then this should fix that. 
* No more (rare) race conditions when processing `ProxyRouterEndpoint` requests that could lead to requests not being handled correctly.
* Better internal corner-case error handling for `ProxyRouterEndpoint` requests, leading to less log spam warnings.
* Improved logging when corner case errors do pop up. If a request is handled in an unexpected way and you have the trace ID from the response headers, then the logs should give you better insight into what happened (i.e. caller or downstream system dropping connection partway through a request).