### PR TITLE
Add getPathTemplate method to RequestInfo

### DIFF
--- a/riposte-spi/src/main/java/com/nike/riposte/server/http/RequestInfo.java
+++ b/riposte-spi/src/main/java/com/nike/riposte/server/http/RequestInfo.java
@@ -43,6 +43,8 @@ public interface RequestInfo<T> {
      * The full URI associated with this request. This will be the raw, potentially encoded, value sent to the server.
      * It may include the query string (use {@link #getPath()} if you don't want the query string).
      *
+     * see {@link #getPathTemplate()} if you are looking for the matching template of the request
+     *
      * Will never be null - the empty string will be used if no URI information was provided.
      */
     public String getUri();
@@ -52,6 +54,8 @@ public interface RequestInfo<T> {
      * query string).
      *
      * The path value returned will be URL decoded before being returned.
+     *
+     * see {@link #getPathTemplate()} if you are looking for the matching template of the request
      *
      * Will never be null - the empty string will be used if no path information could be extracted.
      */
@@ -384,4 +388,18 @@ public interface RequestInfo<T> {
      * do not need to worry about this issue - it's a problem for the server to solve.
      */
     public void releaseMultipartData();
+
+    /**
+     * This will return the path template set by {@link #setPathParamsBasedOnPathTemplate(String)},
+     * which corresponds to an endpoint {@link com.nike.riposte.util.Matcher}'s path template and is automatically set
+     * when a request is matched to an endpoint.
+     *
+     * <p>Example path template: "/app/{appId}/user/{userId}".
+     * Note this different than {@link #getPath()}, which in this example might be "/app/foo/user/bar".
+     *
+     * <p>Will never be null - an empty string will be used if {@link #setPathParamsBasedOnPathTemplate(String)}
+     * was never called (should only happen in error cases where an endpoint was not called).
+     */
+    public String getPathTemplate();
+
 }

--- a/riposte-spi/src/main/java/com/nike/riposte/server/http/impl/RequestInfoImpl.java
+++ b/riposte-spi/src/main/java/com/nike/riposte/server/http/impl/RequestInfoImpl.java
@@ -497,4 +497,12 @@ public class RequestInfoImpl<T> implements RequestInfo<T>, RiposteInternalReques
         return attributes;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getPathTemplate() {
+        return this.pathTemplate == null ? "" : this.pathTemplate;
+    }
+
 }

--- a/riposte-spi/src/test/java/com/nike/riposte/server/http/RequestInfoTest.java
+++ b/riposte-spi/src/test/java/com/nike/riposte/server/http/RequestInfoTest.java
@@ -265,6 +265,11 @@ public class RequestInfoTest {
         }
 
         @Override
+        public String getPathTemplate() {
+            return null;
+        }
+
+        @Override
         public void addRequestAttribute(String attributeName, Object attributeValue) {
 
         }

--- a/riposte-spi/src/test/java/com/nike/riposte/server/http/impl/RequestInfoImplTest.java
+++ b/riposte-spi/src/test/java/com/nike/riposte/server/http/impl/RequestInfoImplTest.java
@@ -448,6 +448,7 @@ public class RequestInfoImplTest {
         assertThat(requestInfo.getPathParam("param2"), is(expectedParam2));
         assertThat(requestInfo.getPathParams().get("param1"), is(expectedParam1));
         assertThat(requestInfo.getPathParams().get("param2"), is(expectedParam2));
+        assertThat(requestInfo.getPathTemplate(), is(pathTemplate));
     }
 
     @Test(expected = PathParameterMatchingException.class)
@@ -912,6 +913,18 @@ public class RequestInfoImplTest {
 
         // then
         assertThat(requestInfo.getRequestAttributes().get(attributeName), is(attributeValue));
+    }
+
+    @Test
+    public void getPathTemplate_returns_empty_string_when_null_value() {
+        // given
+        RequestInfoImpl<?> requestInfo = RequestInfoImpl.dummyInstanceForUnknownRequests();
+
+        // when
+        String pathTemplate = requestInfo.getPathTemplate();
+
+        // then
+        assertThat(pathTemplate, is(""));
     }
 
     public static class TestContentObject {


### PR DESCRIPTION
Per issue #55 , The purpose of this PR is to add a method to get the path template from the request. 

Add a new method, getPathTemplate, to the RequestInfo interface and implementation.