### PR TITLE
FailFast if Content-Length header value is greater than configured max request size

### DIFF
--- a/riposte-core/src/main/java/com/nike/riposte/server/channelpipeline/HttpChannelInitializer.java
+++ b/riposte-core/src/main/java/com/nike/riposte/server/channelpipeline/HttpChannelInitializer.java
@@ -476,7 +476,7 @@ public class HttpChannelInitializer extends ChannelInitializer<SocketChannel> {
 
         // INBOUND - Add RoutingHandler to figure out which endpoint should handle the request and set it on our request
         //           state for later execution
-        p.addLast(ROUTING_HANDLER_NAME, new RoutingHandler(endpoints));
+        p.addLast(ROUTING_HANDLER_NAME, new RoutingHandler(endpoints, maxRequestSizeInBytes));
 
         // INBOUND - Add SecurityValidationHandler to validate the RequestInfo object for the matching endpoint
         p.addLast(SECURITY_VALIDATION_HANDLER_NAME, new SecurityValidationHandler(requestSecurityValidator));

--- a/riposte-core/src/test/java/com/nike/riposte/server/handler/RoutingHandlerTest.java
+++ b/riposte-core/src/test/java/com/nike/riposte/server/handler/RoutingHandlerTest.java
@@ -11,9 +11,20 @@ import com.nike.riposte.server.http.HttpProcessingState;
 import com.nike.riposte.server.http.RequestInfo;
 import com.nike.riposte.server.http.StandardEndpoint;
 import com.nike.riposte.util.Matcher;
-
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.TooLongFrameException;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpObject;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.util.Attribute;
+import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.internal.util.reflection.Whitebox;
 
 import java.util.ArrayList;
@@ -22,12 +33,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
 
-import io.netty.channel.Channel;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.http.HttpObject;
-import io.netty.handler.codec.http.HttpRequest;
-import io.netty.util.Attribute;
-
+import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_LENGTH;
+import static io.netty.handler.codec.http.HttpHeaders.Names.TRANSFER_ENCODING;
+import static io.netty.handler.codec.http.HttpHeaders.Values.CHUNKED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doReturn;
@@ -41,6 +49,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
  *
  * @author Nic Munroe
  */
+@RunWith(DataProviderRunner.class)
 public class RoutingHandlerTest {
 
     private RoutingHandler handlerSpy;
@@ -53,6 +62,9 @@ public class RoutingHandlerTest {
     private Matcher matcherMock;
     private Collection<Endpoint<?>> endpoints;
     private String defaultPath = "/*/*/{vipname}/**";
+    private HttpHeaders httpHeaders;
+    private int maxRequestSizeInBytes;
+    private HttpRequest msg;
 
     @Before
     public void beforeMethod() {
@@ -64,6 +76,9 @@ public class RoutingHandlerTest {
         endpointMock = mock(StandardEndpoint.class);
         matcherMock = mock(Matcher.class);
         endpoints = new ArrayList<>(Collections.singleton(endpointMock));
+        httpHeaders = new DefaultHttpHeaders();
+        maxRequestSizeInBytes = 10;
+        msg = mock(HttpRequest.class);
 
         doReturn(channelMock).when(ctxMock).channel();
         doReturn(stateAttrMock).when(channelMock).attr(ChannelAttributes.HTTP_PROCESSING_STATE_ATTRIBUTE_KEY);
@@ -73,14 +88,15 @@ public class RoutingHandlerTest {
         doReturn(Optional.of(defaultPath)).when(matcherMock).matchesPath(any(RequestInfo.class));
         doReturn(true).when(matcherMock).matchesMethod(any(RequestInfo.class));
         doReturn(requestInfoMock).when(stateMock).getRequestInfo();
+        doReturn(httpHeaders).when(msg).headers();
 
-        handlerSpy = spy(new RoutingHandler(endpoints));
+        handlerSpy = spy(new RoutingHandler(endpoints, maxRequestSizeInBytes));
     }
 
     @Test
     public void constructor_sets_fields_based_on_incoming_args() {
         // when
-        RoutingHandler theHandler = new RoutingHandler(endpoints);
+        RoutingHandler theHandler = new RoutingHandler(endpoints, maxRequestSizeInBytes);
 
         // then
         Collection<Endpoint<?>>
@@ -91,13 +107,13 @@ public class RoutingHandlerTest {
     @Test(expected = IllegalArgumentException.class)
     public void constructor_throws_IllegalArgumentException_if_arg_is_null() {
         // expect
-        new RoutingHandler(null);
+        new RoutingHandler(null, maxRequestSizeInBytes);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void constructor_throws_IllegalArgumentException_if_arg_is_empty() {
         // expect
-        new RoutingHandler(Collections.emptyList());
+        new RoutingHandler(Collections.emptyList(), maxRequestSizeInBytes);
     }
 
     @Test
@@ -182,4 +198,111 @@ public class RoutingHandlerTest {
         // when
         handlerSpy.findSingleEndpointForExecution(requestInfoMock);
     }
+
+    @Test
+    public void doChannelRead_HttpRequest_throws_exception_when_content_length_header_greater_than_configured_global_request_limit() {
+        // given
+        doReturn(null).when(endpointMock).maxRequestSizeInBytesOverride();
+
+        maxRequestSizeInBytes = 10;
+        httpHeaders.set(CONTENT_LENGTH, 100);
+        handlerSpy = spy(new RoutingHandler(endpoints, maxRequestSizeInBytes));
+
+        // when
+        Throwable thrownException = Assertions.catchThrowable(() -> handlerSpy.doChannelRead(ctxMock, msg));
+
+        // then
+        assertThat(thrownException).isExactlyInstanceOf(TooLongFrameException.class);
+        assertThat(thrownException.getMessage()).isEqualTo("Content-Length header value exceeded configured max request size of 10");
+    }
+
+    @DataProvider(value = {
+            "99",
+            "101"
+    })
+    @Test
+    public void doChannelRead_HttpRequest_endpoint_overridden_max_request_size_throws_exception(int maxRequestSize) {
+        // given
+        doReturn(100).when(endpointMock).maxRequestSizeInBytesOverride();
+
+        httpHeaders.set(CONTENT_LENGTH, 101);
+
+        handlerSpy = spy(new RoutingHandler(endpoints, maxRequestSize));
+
+        // when
+        Throwable thrownException = Assertions.catchThrowable(() -> handlerSpy.doChannelRead(ctxMock, msg));
+
+        // then
+        assertThat(thrownException).isExactlyInstanceOf(TooLongFrameException.class);
+        assertThat(thrownException.getMessage()).isEqualTo("Content-Length header value exceeded configured max request size of 100");
+    }
+
+    @Test
+    public void doChannelRead_HttpRequest_under_max_global_request_size_processed_successfully() {
+        // given
+        doReturn(null).when(endpointMock).maxRequestSizeInBytesOverride();
+
+        maxRequestSizeInBytes = 101;
+        httpHeaders.set(CONTENT_LENGTH, 100);
+        handlerSpy = spy(new RoutingHandler(endpoints, maxRequestSizeInBytes));
+
+        // when
+        PipelineContinuationBehavior result = handlerSpy.doChannelRead(ctxMock, msg);
+
+        // then
+        assertThat(result).isEqualTo(PipelineContinuationBehavior.CONTINUE);
+    }
+
+    @DataProvider(value = {
+            "true",
+            "false"
+    })
+    @Test
+    public void doChannelRead_HttpRequest_does_not_throw_TooLongFrameException_if_content_length_header_is_missing(
+            boolean isChunkedTransferEncoding
+    ) {
+        // given
+        if (isChunkedTransferEncoding) {
+            httpHeaders.set(TRANSFER_ENCODING, CHUNKED);
+        }
+
+        doReturn(null).when(endpointMock).maxRequestSizeInBytesOverride();
+
+        maxRequestSizeInBytes = 101;
+        handlerSpy = spy(new RoutingHandler(endpoints, maxRequestSizeInBytes));
+
+        // when
+        PipelineContinuationBehavior result = handlerSpy.doChannelRead(ctxMock, msg);
+
+        // then
+        assertThat(result).isEqualTo(PipelineContinuationBehavior.CONTINUE);
+    }
+
+    @DataProvider(value = {
+            "99",
+            "100"
+    })
+    @Test
+    public void doChannelRead_HttpRequest_does_not_throw_TooLongFrameException_if_content_length_is_less_than_endpoint_overridden_value(
+            int maxRequestSize
+    ) {
+        // given
+        doReturn(100).when(endpointMock).maxRequestSizeInBytesOverride();
+
+        httpHeaders.set(CONTENT_LENGTH, 100);
+
+        handlerSpy = spy(new RoutingHandler(endpoints, maxRequestSize));
+
+        // when
+        PipelineContinuationBehavior result = handlerSpy.doChannelRead(ctxMock, msg);
+
+        // then
+        assertThat(result).isEqualTo(PipelineContinuationBehavior.CONTINUE);
+    }
+
+    @Test
+    public void argsAreEligibleForLinkingAndUnlinkingDistributedTracingInfo_returns_false() {
+        assertThat(handlerSpy.argsAreEligibleForLinkingAndUnlinkingDistributedTracingInfo(null,null,null,null)).isFalse();
+    }
+
 }

--- a/riposte-spi/src/main/java/com/nike/riposte/util/HttpUtils.java
+++ b/riposte-spi/src/main/java/com/nike/riposte/util/HttpUtils.java
@@ -2,6 +2,7 @@ package com.nike.riposte.util;
 
 import com.nike.riposte.server.error.exception.InvalidCharsetInContentTypeHeaderException;
 import com.nike.riposte.server.error.exception.PathParameterMatchingException;
+import com.nike.riposte.server.http.Endpoint;
 import com.nike.riposte.server.http.RequestInfo;
 
 import java.nio.charset.Charset;
@@ -212,5 +213,18 @@ public class HttpUtils {
         }
 
         return downstreamDestinationUriPath;
+    }
+
+    public static boolean isMaxRequestSizeValidationDisabled(int configuredMaxRequestSize) {
+        return configuredMaxRequestSize <= 0;
+    }
+
+    public static int getConfiguredMaxRequestSize(Endpoint<?> endpoint, int globalConfiguredMaxRequestSizeInBytes) {
+        //if the endpoint is null or the endpoint is not overriding, we should return the globally configured value
+        if (endpoint == null || endpoint.maxRequestSizeInBytesOverride() == null) {
+            return globalConfiguredMaxRequestSizeInBytes;
+        }
+
+        return endpoint.maxRequestSizeInBytesOverride();
     }
 }


### PR DESCRIPTION
Per #37 , Configured validation in RoutingHandler to fail fast if the content-length header is set and greater than the configured max request size once we know the endpoint for the request

This was put into the RoutingHandler instead of RequestInfoSetterHandler as we do not know the endpoint yet until after the RoutingHandler figures it out, which is necessary to process an endpoint's override of the global limit.

I also refactored a couple of the requestSize methods into HttpUtils to enable both handlers to share the code of determining the max size and if it is disabled.