### PR TITLE
ProxyRouting downstream Host header should include the port when port is not the default value

### DIFF
--- a/riposte-core/src/main/java/com/nike/riposte/client/asynchttp/netty/StreamingAsyncHttpClient.java
+++ b/riposte-core/src/main/java/com/nike/riposte/client/asynchttp/netty/StreamingAsyncHttpClient.java
@@ -587,7 +587,13 @@ public class StreamingAsyncHttpClient {
     ) {
         CompletableFuture<StreamingChannel> streamingChannel = new CompletableFuture<>();
 
-        initialRequestChunk.headers().set(HttpHeaders.Names.HOST, downstreamHost);
+        // set host header. include port in value when it is a non-default port
+        boolean isDefaultPort = (downstreamPort == 80 && !isSecureHttpsCall)
+                             || (downstreamPort == 443 && isSecureHttpsCall);
+        String hostHeaderValue = (isDefaultPort)
+                                 ? downstreamHost
+                                 : downstreamHost + ":" + downstreamPort;
+        initialRequestChunk.headers().set(HttpHeaders.Names.HOST, hostHeaderValue);
 
         boolean performSubSpanAroundDownstreamCalls = true;
 

--- a/riposte-core/src/test/java/com/nike/riposte/server/componenttest/VerifyProxyRequestsDoNotAlterRequestToDownstreamServiceTest.java
+++ b/riposte-core/src/test/java/com/nike/riposte/server/componenttest/VerifyProxyRequestsDoNotAlterRequestToDownstreamServiceTest.java
@@ -203,7 +203,7 @@ public class VerifyProxyRequestsDoNotAlterRequestToDownstreamServiceTest {
         assertThat(proxyHeaders.get(HttpHeaders.Names.HOST)).isEqualTo("localhost");
         assertThat(proxyHeaders.get(HttpHeaders.Names.CONTENT_LENGTH)).isEqualTo(downstreamHeaders.get(HttpHeaders.Names.CONTENT_LENGTH));
         assertThat(proxyHeaders.get(HttpHeaders.Names.TRANSFER_ENCODING)).isEqualTo(downstreamHeaders.get(HttpHeaders.Names.TRANSFER_ENCODING));
-        assertThat(downstreamHeaders.get(HttpHeaders.Names.HOST)).isEqualTo("127.0.0.1");
+        assertThat(downstreamHeaders.get(HttpHeaders.Names.HOST)).isEqualTo("127.0.0.1:" + downstreamServerConfig.endpointsPort());
 
         //assert trace info added to downstream call
         assertThat(downstreamHeaders.get("X-B3-Sampled")).isNotNull();


### PR DESCRIPTION
When streaming requests for proxyRouterEndpoints the host header value was never including the port in the value.

This PR will change that and the Host header will now contain the port when the port is not a default value

