### PR TITLE
Added EurekaVipAddressRoundRobinWithAzAffinityService to the eureka s…

### DIFF
--- a/riposte-service-registration-eureka/src/main/java/com/nike/riposte/serviceregistration/eureka/helpers/EurekaVipAddressRoundRobinService.java
+++ b/riposte-service-registration-eureka/src/main/java/com/nike/riposte/serviceregistration/eureka/helpers/EurekaVipAddressRoundRobinService.java
@@ -3,24 +3,22 @@ package com.nike.riposte.serviceregistration.eureka.helpers;
 import com.netflix.appinfo.InstanceInfo;
 import com.netflix.discovery.DiscoveryClient;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.Executor;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
-
 import javax.inject.Inject;
 import javax.inject.Named;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 
 /**
  * Service that uses the Eureka discovery client to provide all the instances associated with a VIP name ({@link
  * #getActiveInstanceInfosForVipAddress(String, Optional)}), or the "next" instance that should be called using
  * round-robin strategy ({@link #getActiveInstanceInfoForVipAddress(String, Optional)}.
+ * <p/>
+ * NOTE: If you need your requests routed to instances in the same availability zone, use
+ * {@link EurekaVipAddressRoundRobinWithAzAffinityService}
  * <p/>
  * NOTE: The round-robin counters are on a per-EurekaVipAddressRoundRobinService basis. Each new instance of this class
  * will do its own separate round-robin counting. Therefore you should use a single instance of this class anywhere you
@@ -29,42 +27,13 @@ import javax.inject.Named;
  * @author Nic Munroe
  */
 @SuppressWarnings({"WeakerAccess", "OptionalUsedAsFieldOrParameterType"})
-public class EurekaVipAddressRoundRobinService {
-
+public class EurekaVipAddressRoundRobinService extends EurekaVipAddressService {
     protected final ConcurrentMap<String, AtomicInteger> vipRoundRobinCounterMap = new ConcurrentHashMap<>();
-    protected final Supplier<DiscoveryClient> discoveryClientSupplier;
-    protected DiscoveryClient discoveryClientCache;
 
     @Inject
     public EurekaVipAddressRoundRobinService(@Named("eurekaRoundRobinDiscoveryClientSupplier")
                                              Supplier<DiscoveryClient> discoveryClientSupplier) {
-        this.discoveryClientSupplier = discoveryClientSupplier;
-    }
-
-    /**
-     * A potentially blocking method that returns the list of *active* {@link InstanceInfo} objects eureka has
-     * associated with the given VIP name (i.e. instances whose state is {@link InstanceInfo.InstanceStatus#UP}), or an
-     * empty list if no such instances were found. Will never return null.
-     * <p/>
-     * The eureka discovery client has an internal cache, so this method may return quickly, but if the cache doesn't
-     * have info on the VIP or needs to be refreshed then this method could take as long it takes the eureka discovery
-     * client to do the necessary network calls.
-     * <p/>
-     * TODO: See if Netflix has a newer version of the Eureka client that allows for async nonblocking retrieval via futures.
-     */
-    public List<InstanceInfo> getActiveInstanceInfosForVipAddressBlocking(String vipName) {
-        // Lookup instances by VIP address (the Eureka client uses an internal cache, so this won't necessarily incur
-        //      the cost of a network call)
-        List<InstanceInfo> instancesByVipAddress = discoveryClient().getInstancesByVipAddress(vipName, false);
-
-        // Return an empty list if no registration exists for this VIP
-        if (instancesByVipAddress == null || instancesByVipAddress.isEmpty())
-            return Collections.emptyList();
-
-        // Filter down to just instances that are marked with "up" status.
-        return instancesByVipAddress.stream()
-                                    .filter(ii -> ii.getStatus().equals(InstanceInfo.InstanceStatus.UP))
-                                    .collect(Collectors.toList());
+        super(discoveryClientSupplier);
     }
 
     /**
@@ -74,19 +43,24 @@ public class EurekaVipAddressRoundRobinService {
      * @return The *next* active {@link InstanceInfo} that should be called for the given VIP name (using a round-robin
      * strategy), or an empty Optional if no active instances were found.
      */
+    @Override
     public Optional<InstanceInfo> getActiveInstanceInfoForVipAddressBlocking(String vipName) {
         List<InstanceInfo> instancesByVipAddress = getActiveInstanceInfosForVipAddressBlocking(vipName);
 
         if (instancesByVipAddress.isEmpty())
             return Optional.empty();
 
+        return roundRobinInstanceList(vipName, instancesByVipAddress);
+    }
+
+    protected Optional<InstanceInfo> roundRobinInstanceList(String vipName, List<InstanceInfo> instanceList) {
         // Found at least one "up" instance at this VIP. Grab the AtomicInteger associated with this VIP
         //      (map a new one if necessary).
         AtomicInteger roundRobinCounter = vipRoundRobinCounterMap.computeIfAbsent(vipName, vip -> new AtomicInteger(0));
 
         // Atomically get-and-increment the atomic int associated with this VIP, then mod it against the number of
         //      instances available. This effectively round robins the use of all the instances associated with the VIP.
-        int instanceIndexToUse = roundRobinCounter.getAndIncrement() % instancesByVipAddress.size();
+        int instanceIndexToUse = roundRobinCounter.getAndIncrement() % instanceList.size();
 
         if (instanceIndexToUse < 0) {
             // The counter went high enough to do an integer overflow. Fix the index so we don't blow up this call,
@@ -95,51 +69,6 @@ public class EurekaVipAddressRoundRobinService {
             roundRobinCounter.set(0);
         }
 
-        return Optional.of(instancesByVipAddress.get(instanceIndexToUse));
-    }
-
-    /**
-     * @return A {@link CompletableFuture} that when it completes will return the list of *active* {@link InstanceInfo}
-     * objects eureka has associated with the given VIP name (i.e. instances whose state is {@link
-     * InstanceInfo.InstanceStatus#UP}), or an empty list if no such instances were found (will never return null). If
-     * you pass in an {@link Executor} for the {@code longRunningTaskExecutor} argument then it will be used to execute
-     * the future, otherwise the default will be used (typically the Java common fork-join pool).
-     */
-    public CompletableFuture<List<InstanceInfo>> getActiveInstanceInfosForVipAddress(
-        String vipName, Optional<Executor> longRunningTaskExecutor
-    ) {
-        return longRunningTaskExecutor
-            .map(executor -> CompletableFuture.supplyAsync(
-                () -> getActiveInstanceInfosForVipAddressBlocking(vipName), executor)
-            )
-            .orElse(
-                CompletableFuture.supplyAsync(() -> getActiveInstanceInfosForVipAddressBlocking(vipName))
-            );
-    }
-
-    /**
-     * @return A {@link CompletableFuture} that when it completes will round-robin the instances returned by {@link
-     * #getActiveInstanceInfosForVipAddress(String, Optional)} to determine the *next* active {@link InstanceInfo} that
-     * should be called for the given VIP name, or an empty Optional if no active instances were found. If you pass in
-     * an {@link Executor} for the {@code longRunningTaskExecutor} argument then it will be used to execute the future,
-     * otherwise the default will be used (typically the Java common fork-join pool).
-     */
-    public CompletableFuture<Optional<InstanceInfo>> getActiveInstanceInfoForVipAddress(
-        String vipName, Optional<Executor> longRunningTaskExecutor
-    ) {
-        return longRunningTaskExecutor
-            .map(executor -> CompletableFuture.supplyAsync(
-                () -> getActiveInstanceInfoForVipAddressBlocking(vipName), executor)
-            )
-            .orElse(
-                CompletableFuture.supplyAsync(() -> getActiveInstanceInfoForVipAddressBlocking(vipName))
-            );
-    }
-
-    protected DiscoveryClient discoveryClient() {
-        if (discoveryClientCache == null)
-            discoveryClientCache = discoveryClientSupplier.get();
-
-        return discoveryClientCache;
+        return Optional.of(instanceList.get(instanceIndexToUse));
     }
 }

--- a/riposte-service-registration-eureka/src/main/java/com/nike/riposte/serviceregistration/eureka/helpers/EurekaVipAddressRoundRobinWithAzAffinityService.java
+++ b/riposte-service-registration-eureka/src/main/java/com/nike/riposte/serviceregistration/eureka/helpers/EurekaVipAddressRoundRobinWithAzAffinityService.java
@@ -1,0 +1,71 @@
+package com.nike.riposte.serviceregistration.eureka.helpers;
+
+import com.netflix.appinfo.InstanceInfo;
+import com.netflix.discovery.DiscoveryClient;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+/**
+ * Service that uses the Eureka discovery client to provide all the instances associated with a VIP name ({@link
+ * #getActiveInstanceInfosForVipAddress(String, Optional)}) in the current availability zone., or the "next" instance
+ * that should be called using round-robin strategy ({@link #getActiveInstanceInfoForVipAddress(String, Optional)} in
+ * the current availability zone.
+ * If there are no instances in the current availability zone, this method will round-robin the instances in all
+ * availability zones.
+ * <p/>
+ * NOTE: The round-robin counters are on a per-EurekaVipAddressRoundRobinService basis. Each new instance of this class
+ * will do its own separate round-robin counting. Therefore you should use a single instance of this class anywhere you
+ * want the round robin effect.
+ *
+ */
+@SuppressWarnings({"WeakerAccess", "OptionalUsedAsFieldOrParameterType"})
+public class EurekaVipAddressRoundRobinWithAzAffinityService extends EurekaVipAddressRoundRobinService {
+    protected final String currentAvailabilityZone;
+
+    @Inject
+    public EurekaVipAddressRoundRobinWithAzAffinityService(
+            @Named("eurekaRoundRobinDiscoveryClientSupplier") Supplier<DiscoveryClient> discoveryClientSupplier,
+            @Named("currentAvailabilityZone") String currentAvailabilityZone
+    ) {
+        super(discoveryClientSupplier);
+        this.currentAvailabilityZone = currentAvailabilityZone;
+    }
+
+    /**
+     * Round-robins the instances in the current availability zone returned by
+     * {@link #getActiveInstanceInfosForVipAddressBlocking(String)} to determine the *next* active {@link InstanceInfo}
+     * that should be called for the given VIP name. If there are no instances in the current availability zone, this
+     * method will round-robin the instances in all availability zones.
+     *
+     * @return The *next* active {@link InstanceInfo} that should be called for the given VIP name (using a round-robin
+     * strategy with current availability zone affinity), or an empty Optional if no active instances were found.
+     */
+    @Override
+    public Optional<InstanceInfo> getActiveInstanceInfoForVipAddressBlocking(String vipName) {
+        List<InstanceInfo> instancesByVipAddress = getActiveInstanceInfosForVipAddressBlocking(vipName);
+
+        if (instancesByVipAddress.isEmpty())
+            return Optional.empty();
+
+        List<InstanceInfo> filteredInstanceList = calculateInstanceListWithAzAffinity(instancesByVipAddress);
+        return roundRobinInstanceList(vipName, filteredInstanceList);
+    }
+
+    /**
+     *
+     * @param fullInstanceList list of all instances in the current region
+     * @return list of all instances in the current availability zone. if there are none, it will return the fullInstanceList
+     */
+    protected List<InstanceInfo> calculateInstanceListWithAzAffinity(List<InstanceInfo> fullInstanceList) {
+        List<InstanceInfo> currentAzList = fullInstanceList.stream().
+                filter(instanceInfo ->
+                        currentAvailabilityZone.equalsIgnoreCase(instanceInfo.getMetadata().get("availability-zone"))
+                ).
+                collect(Collectors.toList());
+        return currentAzList.isEmpty() ? fullInstanceList : currentAzList;
+    }
+}

--- a/riposte-service-registration-eureka/src/main/java/com/nike/riposte/serviceregistration/eureka/helpers/EurekaVipAddressService.java
+++ b/riposte-service-registration-eureka/src/main/java/com/nike/riposte/serviceregistration/eureka/helpers/EurekaVipAddressService.java
@@ -1,0 +1,101 @@
+package com.nike.riposte.serviceregistration.eureka.helpers;
+
+import com.netflix.appinfo.InstanceInfo;
+import com.netflix.discovery.DiscoveryClient;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+@SuppressWarnings({"OptionalUsedAsFieldOrParameterType", "WeakerAccess"})
+public abstract class EurekaVipAddressService {
+    protected final Supplier<DiscoveryClient> discoveryClientSupplier;
+    protected DiscoveryClient discoveryClientCache;
+
+    public EurekaVipAddressService(Supplier<DiscoveryClient> discoveryClientSupplier) {
+        this.discoveryClientSupplier = discoveryClientSupplier;
+    }
+    /**
+     * Calls {@link #getActiveInstanceInfosForVipAddressBlocking(String)} to determine
+     * the *next* active {@link InstanceInfo} that should be called for the given VIP name
+     *
+     * @return The *next* active {@link InstanceInfo} that should be called for the given VIP name, or an empty Optional
+     * if no active instances were found.
+     */
+    public abstract Optional<InstanceInfo> getActiveInstanceInfoForVipAddressBlocking(String vipName);
+
+    /**
+     * A potentially blocking method that returns the list of *active* {@link InstanceInfo} objects eureka has
+     * associated with the given VIP name (i.e. instances whose state is {@link InstanceInfo.InstanceStatus#UP}), or an
+     * empty list if no such instances were found. Will never return null.
+     * <p/>
+     * The eureka discovery client has an internal cache, so this method may return quickly, but if the cache doesn't
+     * have info on the VIP or needs to be refreshed then this method could take as long it takes the eureka discovery
+     * client to do the necessary network calls.
+     * <p/>
+     * TODO: See if Netflix has a newer version of the Eureka client that allows for async nonblocking retrieval via futures.
+     */
+    public List<InstanceInfo> getActiveInstanceInfosForVipAddressBlocking(String vipName) {
+        // Lookup instances by VIP address (the Eureka client uses an internal cache, so this won't necessarily incur
+        //      the cost of a network call)
+        List<InstanceInfo> instancesByVipAddress = discoveryClient().getInstancesByVipAddress(vipName, false);
+
+        // Return an empty list if no registration exists for this VIP
+        if (instancesByVipAddress == null || instancesByVipAddress.isEmpty())
+            return Collections.emptyList();
+
+        // Filter down to just instances that are marked with "up" status.
+        return instancesByVipAddress.stream()
+                .filter(ii -> ii.getStatus().equals(InstanceInfo.InstanceStatus.UP))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * @return A {@link CompletableFuture} that when it completes will return the list of *active* {@link InstanceInfo}
+     * objects eureka has associated with the given VIP name (i.e. instances whose state is {@link
+     * InstanceInfo.InstanceStatus#UP}), or an empty list if no such instances were found (will never return null). If
+     * you pass in an {@link Executor} for the {@code longRunningTaskExecutor} argument then it will be used to execute
+     * the future, otherwise the default will be used (typically the Java common fork-join pool).
+     */
+    public CompletableFuture<List<InstanceInfo>> getActiveInstanceInfosForVipAddress(
+            String vipName, Optional<Executor> longRunningTaskExecutor
+    ) {
+        return longRunningTaskExecutor
+                .map(executor -> CompletableFuture.supplyAsync(
+                        () -> getActiveInstanceInfosForVipAddressBlocking(vipName), executor)
+                )
+                .orElse(
+                        CompletableFuture.supplyAsync(() -> getActiveInstanceInfosForVipAddressBlocking(vipName))
+                );
+    }
+
+    /**
+     * @return A {@link CompletableFuture} that when it completes will call {@link
+     * #getActiveInstanceInfosForVipAddress(String, Optional)} to determine the *next* active {@link InstanceInfo} that
+     * should be called for the given VIP name, or an empty Optional if no active instances were found. If you pass in
+     * an {@link Executor} for the {@code longRunningTaskExecutor} argument then it will be used to execute the future,
+     * otherwise the default will be used (typically the Java common fork-join pool).
+     */
+    public CompletableFuture<Optional<InstanceInfo>> getActiveInstanceInfoForVipAddress(
+            String vipName, Optional<Executor> longRunningTaskExecutor
+    ) {
+        return longRunningTaskExecutor
+                .map(executor -> CompletableFuture.supplyAsync(
+                        () -> getActiveInstanceInfoForVipAddressBlocking(vipName), executor)
+                )
+                .orElse(
+                        CompletableFuture.supplyAsync(() -> getActiveInstanceInfoForVipAddressBlocking(vipName))
+                );
+    }
+
+    protected DiscoveryClient discoveryClient() {
+        if (discoveryClientCache == null)
+            discoveryClientCache = discoveryClientSupplier.get();
+
+        return discoveryClientCache;
+    }
+}

--- a/riposte-service-registration-eureka/src/test/java/com/nike/riposte/serviceregistration/eureka/helpers/EurekaVipAddressRoundRobinServiceTest.java
+++ b/riposte-service-registration-eureka/src/test/java/com/nike/riposte/serviceregistration/eureka/helpers/EurekaVipAddressRoundRobinServiceTest.java
@@ -2,9 +2,7 @@ package com.nike.riposte.serviceregistration.eureka.helpers;
 
 import com.netflix.appinfo.InstanceInfo;
 import com.netflix.discovery.DiscoveryClient;
-import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -16,10 +14,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
@@ -49,135 +44,6 @@ public class EurekaVipAddressRoundRobinServiceTest {
         vip = UUID.randomUUID().toString();
         discoveryClientMock = mock(DiscoveryClient.class);
         serviceSpy = spy(new EurekaVipAddressRoundRobinService(() -> discoveryClientMock));
-    }
-
-    @Test
-    public void getActiveInstanceInfosForVipAddressBlocking_retrieves_active_InstanceInfos_by_vip_from_discovery_client() {
-        // given
-        InstanceInfo active1 = mock(InstanceInfo.class);
-        InstanceInfo active2 = mock(InstanceInfo.class);
-        InstanceInfo down = mock(InstanceInfo.class);
-        InstanceInfo outOfService = mock(InstanceInfo.class);
-        InstanceInfo starting = mock(InstanceInfo.class);
-        InstanceInfo unknown = mock(InstanceInfo.class);
-        doReturn(InstanceInfo.InstanceStatus.UP).when(active1).getStatus();
-        doReturn(InstanceInfo.InstanceStatus.UP).when(active2).getStatus();
-        doReturn(InstanceInfo.InstanceStatus.DOWN).when(down).getStatus();
-        doReturn(InstanceInfo.InstanceStatus.OUT_OF_SERVICE).when(outOfService).getStatus();
-        doReturn(InstanceInfo.InstanceStatus.STARTING).when(starting).getStatus();
-        doReturn(InstanceInfo.InstanceStatus.UNKNOWN).when(unknown).getStatus();
-        List<InstanceInfo> allInstancesForVip = Arrays.asList(active1, down, outOfService, active2, starting, unknown);
-        doReturn(allInstancesForVip).when(discoveryClientMock).getInstancesByVipAddress(vip, false);
-
-        // when
-        List<InstanceInfo> result = serviceSpy.getActiveInstanceInfosForVipAddressBlocking(vip);
-
-        // then
-        List<InstanceInfo> expected = Arrays.asList(active1, active2);
-        assertThat(result).isEqualTo(expected);
-    }
-
-    @Test
-    public void getActiveInstanceInfosForVipAddressBlocking_returns_empty_list_if_discovery_client_returns_null() {
-        // given
-        doReturn(null).when(discoveryClientMock).getInstancesByVipAddress(vip, false);
-
-        // when
-        List<InstanceInfo> result = serviceSpy.getActiveInstanceInfosForVipAddressBlocking(vip);
-
-        // then
-        assertThat(result)
-            .isNotNull()
-            .isEmpty();
-    }
-
-    @Test
-    public void getActiveInstanceInfosForVipAddressBlocking_returns_empty_list_if_discovery_client_returns_empty_list() {
-        // given
-        doReturn(Collections.emptyList()).when(discoveryClientMock).getInstancesByVipAddress(vip, false);
-
-        // when
-        List<InstanceInfo> result = serviceSpy.getActiveInstanceInfosForVipAddressBlocking(vip);
-
-        // then
-        assertThat(result)
-            .isNotNull()
-            .isEmpty();
-    }
-
-    private static class SpyableExecutor implements Executor {
-        @Override
-        public void execute(Runnable command) {
-            Executors.newSingleThreadExecutor().execute(command);
-        }
-    }
-
-    @DataProvider(value = {
-        "true",
-        "false"
-    }, splitBy = "\\|")
-    @Test
-    public void getActiveInstanceInfosForVipAddress_returns_future_that_returns_data_from_getActiveInstanceInfosForVipAddressBlocking(boolean useExecutor) {
-        // given
-        InstanceInfo iiMock = mock(InstanceInfo.class);
-        List<InstanceInfo> expectedInstances = Collections.singletonList(iiMock);
-        doReturn(expectedInstances).when(serviceSpy).getActiveInstanceInfosForVipAddressBlocking(vip);
-        Optional<Executor> executorOpt = useExecutor ? Optional.of(Executors.newSingleThreadExecutor()) : Optional.empty();
-
-        // when
-        CompletableFuture<List<InstanceInfo>> result = serviceSpy.getActiveInstanceInfosForVipAddress(vip, executorOpt);
-
-        // then
-        assertThat(result.join()).isEqualTo(expectedInstances);
-    }
-
-    @Test
-    public void getActiveInstanceInfosForVipAddress_uses_provided_executor_for_future_if_provided_one() {
-        // given
-        InstanceInfo iiMock = mock(InstanceInfo.class);
-        List<InstanceInfo> expectedInstances = Collections.singletonList(iiMock);
-        doReturn(expectedInstances).when(serviceSpy).getActiveInstanceInfosForVipAddressBlocking(vip);
-        Executor executorSpy = spy(new SpyableExecutor());
-
-        // when
-        CompletableFuture<List<InstanceInfo>> result = serviceSpy.getActiveInstanceInfosForVipAddress(vip, Optional.of(executorSpy));
-
-        // then
-        assertThat(result.join()).isEqualTo(expectedInstances);
-        verify(executorSpy).execute(any(Runnable.class));
-    }
-
-    @DataProvider(value = {
-        "true",
-        "false"
-    }, splitBy = "\\|")
-    @Test
-    public void getActiveInstanceInfoForVipAddress_returns_future_that_returns_data_from_getActiveInstanceInfoForVipAddressBlocking(boolean useExecutor) {
-        // given
-        InstanceInfo iiMock = mock(InstanceInfo.class);
-        doReturn(Optional.of(iiMock)).when(serviceSpy).getActiveInstanceInfoForVipAddressBlocking(vip);
-        Optional<Executor> executorOpt = useExecutor ? Optional.of(Executors.newSingleThreadExecutor()) : Optional.empty();
-
-        // when
-        CompletableFuture<Optional<InstanceInfo>> result = serviceSpy.getActiveInstanceInfoForVipAddress(vip, executorOpt);
-
-        // then
-        assertThat(result.join()).isEqualTo(Optional.of(iiMock));
-    }
-
-    @Test
-    public void getActiveInstanceInfoForVipAddress_uses_provided_executor_for_future_if_provided_one() {
-        // given
-        InstanceInfo iiMock = mock(InstanceInfo.class);
-        doReturn(Optional.of(iiMock)).when(serviceSpy).getActiveInstanceInfoForVipAddressBlocking(vip);
-        Executor executorSpy = spy(new SpyableExecutor());
-
-        // when
-        CompletableFuture<Optional<InstanceInfo>> result = serviceSpy.getActiveInstanceInfoForVipAddress(vip, Optional.of(executorSpy));
-
-        // then
-        assertThat(result.join()).isEqualTo(Optional.of(iiMock));
-        verify(executorSpy).execute(any(Runnable.class));
     }
 
     private List<InstanceInfo> generateListWithMockInstanceInfos(int numInstanceInfos) {

--- a/riposte-service-registration-eureka/src/test/java/com/nike/riposte/serviceregistration/eureka/helpers/EurekaVipAddressRoundRobinWithAzAffinityServiceTest.java
+++ b/riposte-service-registration-eureka/src/test/java/com/nike/riposte/serviceregistration/eureka/helpers/EurekaVipAddressRoundRobinWithAzAffinityServiceTest.java
@@ -1,0 +1,145 @@
+package com.nike.riposte.serviceregistration.eureka.helpers;
+
+import com.netflix.appinfo.InstanceInfo;
+import com.netflix.discovery.DiscoveryClient;
+import org.assertj.core.util.Lists;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+@SuppressWarnings("ConstantConditions")
+public class EurekaVipAddressRoundRobinWithAzAffinityServiceTest {
+
+    private String vip;
+    private DiscoveryClient discoveryClientMock;
+    private EurekaVipAddressRoundRobinWithAzAffinityService serviceSpy;
+
+    @Before
+    public void beforeMethod() {
+        vip = UUID.randomUUID().toString();
+        discoveryClientMock = mock(DiscoveryClient.class);
+        serviceSpy = spy(new EurekaVipAddressRoundRobinWithAzAffinityService(() -> discoveryClientMock, "us-west-2a"));
+    }
+
+    @Test
+    public void zeroInstances() {
+        // given
+        List<InstanceInfo> expectedInstances = Collections.emptyList();
+        doReturn(expectedInstances).when(serviceSpy).getActiveInstanceInfosForVipAddressBlocking(vip);
+        // when
+        Optional<InstanceInfo> result = serviceSpy.getActiveInstanceInfoForVipAddressBlocking(vip);
+        //then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void roundRobinsSingleInstanceInAzAndIgnoresOtherAzInstances() {
+        // given
+        List<InstanceInfo> expectedInstances = generateListWithMockInstanceInfos(Lists.newArrayList("us-west-2a", "us-west-2b", "us-west-2c"));
+        doReturn(expectedInstances).when(serviceSpy).getActiveInstanceInfosForVipAddressBlocking(vip);
+
+        // when
+        Optional<InstanceInfo> result1 = serviceSpy.getActiveInstanceInfoForVipAddressBlocking(vip);
+        Optional<InstanceInfo> result2 = serviceSpy.getActiveInstanceInfoForVipAddressBlocking(vip);
+        Optional<InstanceInfo> result3 = serviceSpy.getActiveInstanceInfoForVipAddressBlocking(vip);
+        Optional<InstanceInfo> result4 = serviceSpy.getActiveInstanceInfoForVipAddressBlocking(vip);
+
+        // then
+        assertThat(result1).isNotEmpty();
+        assertThat(result1.get()).isEqualTo(expectedInstances.get(0));
+        assertThat(result2).isNotEmpty();
+        assertThat(result2.get()).isEqualTo(expectedInstances.get(0));
+        assertThat(result3).isNotEmpty();
+        assertThat(result3.get()).isEqualTo(expectedInstances.get(0));
+        assertThat(result4).isNotEmpty();
+        assertThat(result4.get()).isEqualTo(expectedInstances.get(0));
+    }
+
+    @Test
+    public void roundRobinsDoesNotTriggerNPEWhenNoAvailabilityZoneIsPresentInTheMetadata() {
+        // given
+        InstanceInfo iiMock = mock(InstanceInfo.class);
+        doReturn(new HashMap<>()).when(iiMock).getMetadata();
+        doReturn(InstanceInfo.InstanceStatus.UP).when(iiMock).getStatus();
+        List<InstanceInfo> expectedInstances = Lists.newArrayList(iiMock);
+        doReturn(expectedInstances).when(serviceSpy).getActiveInstanceInfosForVipAddressBlocking(vip);
+
+        // when
+        Optional<InstanceInfo> result = serviceSpy.getActiveInstanceInfoForVipAddressBlocking(vip);
+
+        // then
+        assertThat(result).isNotEmpty();
+        assertThat(result.get()).isEqualTo(expectedInstances.get(0));
+    }
+
+    @Test
+    public void roundRobinsMultipleInstancesInAzAndIgnoresOtherAzInstances() {
+        // given
+        List<InstanceInfo> expectedInstances = generateListWithMockInstanceInfos(Lists.newArrayList("us-west-2a", "us-west-2a", "us-west-2a", "us-west-2b", "us-west-2b", "us-west-2c", "us-west-2c"));
+        doReturn(expectedInstances).when(serviceSpy).getActiveInstanceInfosForVipAddressBlocking(vip);
+
+        // when
+        Optional<InstanceInfo> result1 = serviceSpy.getActiveInstanceInfoForVipAddressBlocking(vip);
+        Optional<InstanceInfo> result2 = serviceSpy.getActiveInstanceInfoForVipAddressBlocking(vip);
+        Optional<InstanceInfo> result3 = serviceSpy.getActiveInstanceInfoForVipAddressBlocking(vip);
+        Optional<InstanceInfo> result4 = serviceSpy.getActiveInstanceInfoForVipAddressBlocking(vip);
+
+        // then
+        assertThat(result1).isNotEmpty();
+        assertThat(result1.get()).isEqualTo(expectedInstances.get(0));
+        assertThat(result2).isNotEmpty();
+        assertThat(result2.get()).isEqualTo(expectedInstances.get(1));
+        assertThat(result3).isNotEmpty();
+        assertThat(result3.get()).isEqualTo(expectedInstances.get(2));
+        assertThat(result4).isNotEmpty();
+        assertThat(result4.get()).isEqualTo(expectedInstances.get(0));
+    }
+
+    @Test
+    public void roundRobinsOriginalListWhenNoInstancesAreInSameAZ() {
+        // given
+        List<InstanceInfo> expectedInstances = generateListWithMockInstanceInfos(Lists.newArrayList("us-west-2b", "us-west-2b", "us-west-2c"));
+        doReturn(expectedInstances).when(serviceSpy).getActiveInstanceInfosForVipAddressBlocking(vip);
+
+        // when
+        Optional<InstanceInfo> result1 = serviceSpy.getActiveInstanceInfoForVipAddressBlocking(vip);
+        Optional<InstanceInfo> result2 = serviceSpy.getActiveInstanceInfoForVipAddressBlocking(vip);
+        Optional<InstanceInfo> result3 = serviceSpy.getActiveInstanceInfoForVipAddressBlocking(vip);
+        Optional<InstanceInfo> result4 = serviceSpy.getActiveInstanceInfoForVipAddressBlocking(vip);
+
+        // then
+        assertThat(result1).isNotEmpty();
+        assertThat(result1.get()).isEqualTo(expectedInstances.get(0));
+        assertThat(result2).isNotEmpty();
+        assertThat(result2.get()).isEqualTo(expectedInstances.get(1));
+        assertThat(result3).isNotEmpty();
+        assertThat(result3.get()).isEqualTo(expectedInstances.get(2));
+        assertThat(result4).isNotEmpty();
+        assertThat(result4.get()).isEqualTo(expectedInstances.get(0));
+    }
+
+    private List<InstanceInfo> generateListWithMockInstanceInfos(List<String> availabilityZones) {
+        List<InstanceInfo> instanceInfos = new ArrayList<>();
+        for (String az : availabilityZones) {
+            InstanceInfo iiMock = mock(InstanceInfo.class);
+            Map<String, String> metaData = new HashMap<>();
+            metaData.put("availability-zone", az);
+            doReturn(metaData).when(iiMock).getMetadata();
+            doReturn(InstanceInfo.InstanceStatus.UP).when(iiMock).getStatus();
+            instanceInfos.add(iiMock);
+        }
+        return instanceInfos;
+    }
+}

--- a/riposte-service-registration-eureka/src/test/java/com/nike/riposte/serviceregistration/eureka/helpers/EurekaVipAddressServiceTest.java
+++ b/riposte-service-registration-eureka/src/test/java/com/nike/riposte/serviceregistration/eureka/helpers/EurekaVipAddressServiceTest.java
@@ -1,0 +1,195 @@
+package com.nike.riposte.serviceregistration.eureka.helpers;
+
+import com.netflix.appinfo.InstanceInfo;
+import com.netflix.discovery.DiscoveryClient;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import org.assertj.core.util.Lists;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.internal.util.reflection.Whitebox;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests the functionality of {@link EurekaVipAddressRoundRobinService}
+ *
+ * @author Nic Munroe
+ */
+@RunWith(DataProviderRunner.class)
+public class EurekaVipAddressServiceTest {
+
+    private String vip;
+    private DiscoveryClient discoveryClientMock;
+    private EurekaVipAddressRoundRobinService serviceSpy;
+
+    @Before
+    public void beforeMethod() {
+        vip = UUID.randomUUID().toString();
+        discoveryClientMock = mock(DiscoveryClient.class);
+        serviceSpy = spy(new EurekaVipAddressRoundRobinService(() -> discoveryClientMock));
+    }
+
+    @Test
+    public void getActiveInstanceInfosForVipAddressBlocking_retrieves_active_InstanceInfos_by_vip_from_discovery_client() {
+        // given
+        InstanceInfo active1 = mock(InstanceInfo.class);
+        InstanceInfo active2 = mock(InstanceInfo.class);
+        InstanceInfo down = mock(InstanceInfo.class);
+        InstanceInfo outOfService = mock(InstanceInfo.class);
+        InstanceInfo starting = mock(InstanceInfo.class);
+        InstanceInfo unknown = mock(InstanceInfo.class);
+        doReturn(InstanceInfo.InstanceStatus.UP).when(active1).getStatus();
+        doReturn(InstanceInfo.InstanceStatus.UP).when(active2).getStatus();
+        doReturn(InstanceInfo.InstanceStatus.DOWN).when(down).getStatus();
+        doReturn(InstanceInfo.InstanceStatus.OUT_OF_SERVICE).when(outOfService).getStatus();
+        doReturn(InstanceInfo.InstanceStatus.STARTING).when(starting).getStatus();
+        doReturn(InstanceInfo.InstanceStatus.UNKNOWN).when(unknown).getStatus();
+        List<InstanceInfo> allInstancesForVip = Arrays.asList(active1, down, outOfService, active2, starting, unknown);
+        doReturn(allInstancesForVip).when(discoveryClientMock).getInstancesByVipAddress(vip, false);
+
+        // when
+        List<InstanceInfo> result = serviceSpy.getActiveInstanceInfosForVipAddressBlocking(vip);
+
+        // then
+        List<InstanceInfo> expected = Arrays.asList(active1, active2);
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    public void getActiveInstanceInfosForVipAddressBlocking_returns_empty_list_if_discovery_client_returns_null() {
+        // given
+        doReturn(null).when(discoveryClientMock).getInstancesByVipAddress(vip, false);
+
+        // when
+        List<InstanceInfo> result = serviceSpy.getActiveInstanceInfosForVipAddressBlocking(vip);
+
+        // then
+        assertThat(result)
+            .isNotNull()
+            .isEmpty();
+    }
+
+    @Test
+    public void getActiveInstanceInfosForVipAddressBlocking_returns_empty_list_if_discovery_client_returns_empty_list() {
+        // given
+        doReturn(Collections.emptyList()).when(discoveryClientMock).getInstancesByVipAddress(vip, false);
+
+        // when
+        List<InstanceInfo> result = serviceSpy.getActiveInstanceInfosForVipAddressBlocking(vip);
+
+        // then
+        assertThat(result)
+            .isNotNull()
+            .isEmpty();
+    }
+
+    private static class SpyableExecutor implements Executor {
+        @Override
+        public void execute(Runnable command) {
+            Executors.newSingleThreadExecutor().execute(command);
+        }
+    }
+
+    @DataProvider(value = {
+        "true",
+        "false"
+    }, splitBy = "\\|")
+    @Test
+    public void getActiveInstanceInfosForVipAddress_returns_future_that_returns_data_from_getActiveInstanceInfosForVipAddressBlocking(boolean useExecutor) {
+        // given
+        InstanceInfo iiMock = mock(InstanceInfo.class);
+        List<InstanceInfo> expectedInstances = Collections.singletonList(iiMock);
+        doReturn(expectedInstances).when(serviceSpy).getActiveInstanceInfosForVipAddressBlocking(vip);
+        Optional<Executor> executorOpt = useExecutor ? Optional.of(Executors.newSingleThreadExecutor()) : Optional.empty();
+
+        // when
+        CompletableFuture<List<InstanceInfo>> result = serviceSpy.getActiveInstanceInfosForVipAddress(vip, executorOpt);
+
+        // then
+        assertThat(result.join()).isEqualTo(expectedInstances);
+    }
+
+    @Test
+    public void getActiveInstanceInfosForVipAddress_uses_provided_executor_for_future_if_provided_one() {
+        // given
+        InstanceInfo iiMock = mock(InstanceInfo.class);
+        List<InstanceInfo> expectedInstances = Collections.singletonList(iiMock);
+        doReturn(expectedInstances).when(serviceSpy).getActiveInstanceInfosForVipAddressBlocking(vip);
+        Executor executorSpy = spy(new SpyableExecutor());
+
+        // when
+        CompletableFuture<List<InstanceInfo>> result = serviceSpy.getActiveInstanceInfosForVipAddress(vip, Optional.of(executorSpy));
+
+        // then
+        assertThat(result.join()).isEqualTo(expectedInstances);
+        verify(executorSpy).execute(any(Runnable.class));
+    }
+
+    @DataProvider(value = {
+        "true",
+        "false"
+    }, splitBy = "\\|")
+    @Test
+    public void getActiveInstanceInfoForVipAddress_returns_future_that_returns_data_from_getActiveInstanceInfoForVipAddressBlocking(boolean useExecutor) {
+        // given
+        InstanceInfo iiMock = mock(InstanceInfo.class);
+        doReturn(Optional.of(iiMock)).when(serviceSpy).getActiveInstanceInfoForVipAddressBlocking(vip);
+        Optional<Executor> executorOpt = useExecutor ? Optional.of(Executors.newSingleThreadExecutor()) : Optional.empty();
+
+        // when
+        CompletableFuture<Optional<InstanceInfo>> result = serviceSpy.getActiveInstanceInfoForVipAddress(vip, executorOpt);
+
+        // then
+        assertThat(result.join()).isEqualTo(Optional.of(iiMock));
+    }
+
+    @Test
+    public void getActiveInstanceInfoForVipAddress_uses_provided_executor_for_future_if_provided_one() {
+        // given
+        InstanceInfo iiMock = mock(InstanceInfo.class);
+        doReturn(Optional.of(iiMock)).when(serviceSpy).getActiveInstanceInfoForVipAddressBlocking(vip);
+        Executor executorSpy = spy(new SpyableExecutor());
+
+        // when
+        CompletableFuture<Optional<InstanceInfo>> result = serviceSpy.getActiveInstanceInfoForVipAddress(vip, Optional.of(executorSpy));
+
+        // then
+        assertThat(result.join()).isEqualTo(Optional.of(iiMock));
+        verify(executorSpy).execute(any(Runnable.class));
+    }
+
+    @Test
+    public void roundRobinInstanceListWhenWeExperienceIntegerOverflowTest() {
+        // given
+        InstanceInfo iiMock = mock(InstanceInfo.class);
+        List<InstanceInfo> instances = Lists.newArrayList(iiMock, iiMock, iiMock);
+        serviceSpy.vipRoundRobinCounterMap.put("myVip", new AtomicInteger(Integer.MAX_VALUE));
+        // when
+        Optional<InstanceInfo> result1 = serviceSpy.roundRobinInstanceList("myVip", instances);
+        Optional<InstanceInfo> result2 = serviceSpy.roundRobinInstanceList("myVip", instances);
+        Optional<InstanceInfo> result3 = serviceSpy.roundRobinInstanceList("myVip", instances);
+        // then
+        assertThat(result1).isNotEmpty();
+        assertThat(result2).isNotEmpty();
+        assertThat(result3).isNotEmpty();
+        assertThat(serviceSpy.vipRoundRobinCounterMap.get("myVip").intValue()).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
…ub-module. This service will round-robin requests to instances in the same availability zone as the current server. If there are no instances in the current availability zone, it will round-robin instances in all availability zones. Routing requests this way has the advantage of lower response times and lower data transfer costs.