### PR TITLE
Enable Endpoints to require request content

### DIFF
--- a/riposte-core/src/main/java/com/nike/riposte/server/http/ProxyRouterEndpoint.java
+++ b/riposte-core/src/main/java/com/nike/riposte/server/http/ProxyRouterEndpoint.java
@@ -90,6 +90,15 @@ public abstract class ProxyRouterEndpoint implements Endpoint {
     }
 
     /**
+     * Proxy router endpoints don't generally want to require request content due to the varied request types it can
+     * serve. This is similar and goes in sync with {@link #requestContentType()} and {@link #isValidateRequestContent(RequestInfo)}
+     */
+    @Override
+    public boolean isRequireRequestContent() {
+        return false;
+    }
+
+    /**
      * Helper method that generates a {@link HttpRequest} for the downstream call's first chunk that uses the given
      * downstreamPath and downstreamMethod, and the query string and headers from the incomingRequest will be added and
      * passed through without modification.

--- a/riposte-core/src/test/java/com/nike/riposte/server/http/ProxyRouterEndpointTest.java
+++ b/riposte-core/src/test/java/com/nike/riposte/server/http/ProxyRouterEndpointTest.java
@@ -1,0 +1,46 @@
+package com.nike.riposte.server.http;
+
+import com.nike.riposte.util.Matcher;
+import io.netty.channel.ChannelHandlerContext;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ProxyRouterEndpointTest {
+
+    ProxyRouterEndpoint defaultImpl;
+
+    @Before
+    public void setup() {
+        defaultImpl = new ProxyRouterEndpoint() {
+            @Override
+            public CompletableFuture<DownstreamRequestFirstChunkInfo> getDownstreamRequestFirstChunkInfo(RequestInfo<?> request, Executor longRunningTaskExecutor, ChannelHandlerContext ctx) {
+                return null;
+            }
+
+            @Override
+            public Matcher requestMatcher() {
+                return null;
+            }
+        };
+    }
+
+    @Test
+    public void isRequireRequestContent_returnsFalse() {
+        assertThat(defaultImpl.isRequireRequestContent()).isFalse();
+    }
+
+    @Test
+    public void isValidateRequestContent_returnsFalse() {
+        assertThat(defaultImpl.isValidateRequestContent(null)).isFalse();
+    }
+
+    @Test
+    public void requestContentType_returnsNull() {
+        assertThat(defaultImpl.requestContentType()).isNull();
+    }
+}

--- a/riposte-spi/src/main/java/com/nike/backstopper/handler/riposte/listener/impl/BackstopperRiposteFrameworkErrorHandlerListener.java
+++ b/riposte-spi/src/main/java/com/nike/backstopper/handler/riposte/listener/impl/BackstopperRiposteFrameworkErrorHandlerListener.java
@@ -26,6 +26,7 @@ import com.nike.riposte.server.error.exception.NonblockingEndpointCompletableFut
 import com.nike.riposte.server.error.exception.PathNotFound404Exception;
 import com.nike.riposte.server.error.exception.PathParameterMatchingException;
 import com.nike.riposte.server.error.exception.RequestContentDeserializationException;
+import com.nike.riposte.server.error.exception.MissingRequiredContentException;
 import com.nike.riposte.server.error.exception.RequestTooBigException;
 import com.nike.riposte.server.error.exception.TooManyOpenChannelsException;
 import com.nike.riposte.server.error.exception.Unauthorized401Exception;
@@ -209,6 +210,17 @@ public class BackstopperRiposteFrameworkErrorHandlerListener implements ApiExcep
             return ApiExceptionHandlerListenerResult.handleResponse(
                 singletonError(projectApiErrors.getForbiddenApiError()),
                 extraDetails
+            );
+        }
+
+        if (ex instanceof MissingRequiredContentException) {
+            MissingRequiredContentException theEx = (MissingRequiredContentException) ex;
+            return ApiExceptionHandlerListenerResult.handleResponse(
+                    singletonError(projectApiErrors.getMissingExpectedContentApiError()),
+                    Arrays.asList(Pair.of("incoming_request_path", theEx.path),
+                            Pair.of("incoming_request_method", theEx.method),
+                            Pair.of("endpoint_class_name", theEx.endpointClassName)
+                    )
             );
         }
 

--- a/riposte-spi/src/main/java/com/nike/riposte/server/error/exception/MissingRequiredContentException.java
+++ b/riposte-spi/src/main/java/com/nike/riposte/server/error/exception/MissingRequiredContentException.java
@@ -1,0 +1,30 @@
+package com.nike.riposte.server.error.exception;
+
+import com.nike.riposte.server.http.Endpoint;
+import com.nike.riposte.server.http.RequestInfo;
+
+public class MissingRequiredContentException extends RuntimeException {
+
+    public final String path;
+    public final String method;
+    public final String endpointClassName;
+
+    public MissingRequiredContentException() {
+        this("null", "null", "null");
+    }
+
+    public MissingRequiredContentException(String path, String method, String endpointClassName) {
+        this.path = path;
+        this.method = method;
+        this.endpointClassName = endpointClassName;
+    }
+
+    public MissingRequiredContentException(RequestInfo<?> requestInfo, Endpoint<?> endpoint) {
+        this(
+                requestInfo == null? "null" : requestInfo.getPath(),
+                requestInfo == null? "null" : requestInfo.getMethod() == null ? "null" : requestInfo.getMethod().name(),
+                endpoint == null ? "null" : endpoint.getClass().getSimpleName()
+        );
+    }
+
+}

--- a/riposte-spi/src/main/java/com/nike/riposte/server/http/Endpoint.java
+++ b/riposte-spi/src/main/java/com/nike/riposte/server/http/Endpoint.java
@@ -1,6 +1,7 @@
 package com.nike.riposte.server.http;
 
 import com.nike.riposte.server.config.ServerConfig;
+import com.nike.riposte.server.error.exception.MissingRequiredContentException;
 import com.nike.riposte.util.Matcher;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -72,6 +73,19 @@ public interface Endpoint<I> {
      */
     default boolean isValidateRequestContent(@SuppressWarnings("UnusedParameters") RequestInfo<?> request) {
         return true;
+    }
+
+    /**
+     * @return true if this endpoint wants validation on the {@link RequestInfo#getContent()} to ensure it always has
+     * content. If this returns true and there was no content passed,
+     * {@link MissingRequiredContentException} will be thrown,
+     * which is mapped to an appropriate HTTP status code 400 error response by the default riposte exception handler
+     * <p>
+     * By default this will return false when {@link #requestContentType()} is null or {@link Void} type (indicating you don't expect any content), true otherwise.
+     */
+    default boolean isRequireRequestContent() {
+        TypeReference<I> requestContentType = requestContentType();
+        return requestContentType != null && !Void.class.equals(requestContentType.getType());
     }
 
     /**

--- a/riposte-spi/src/test/java/com/nike/riposte/server/error/exception/MissingRequiredContentExceptionTest.java
+++ b/riposte-spi/src/test/java/com/nike/riposte/server/error/exception/MissingRequiredContentExceptionTest.java
@@ -1,0 +1,97 @@
+package com.nike.riposte.server.error.exception;
+
+import com.nike.backstopper.handler.riposte.listener.impl.BackstopperRiposteFrameworkErrorHandlerListenerTest;
+import com.nike.riposte.server.http.Endpoint;
+import com.nike.riposte.server.http.RequestInfo;
+import com.nike.riposte.util.Matcher;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import io.netty.handler.codec.http.HttpMethod;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+@RunWith(DataProviderRunner.class)
+public class MissingRequiredContentExceptionTest {
+
+    @Test
+    public void no_arg_constructor_works_as_expected() {
+        MissingRequiredContentException ex = new MissingRequiredContentException();
+
+        assertThat(ex.endpointClassName).isEqualTo("null");
+        assertThat(ex.method).isEqualTo("null");
+        assertThat(ex.path).isEqualTo("null");
+    }
+
+    @Test
+    public void three_arg_constructor_works_as_expected() {
+        // given
+        String path = "/path";
+        String method = "POST";
+        String endpointClassName = "endpoint";
+
+        // when
+        MissingRequiredContentException ex = new MissingRequiredContentException(path, method, endpointClassName);
+
+        // then
+        assertThat(ex.endpointClassName).isEqualTo(endpointClassName);
+        assertThat(ex.method).isEqualTo(method);
+        assertThat(ex.path).isEqualTo(path);
+    }
+
+    @Test
+    public void two_arg_constructor_works_as_expected_null_inputs() {
+        // when
+        MissingRequiredContentException ex = new MissingRequiredContentException(null, null);
+
+        // then
+        assertThat(ex.endpointClassName).isEqualTo("null");
+        assertThat(ex.method).isEqualTo("null");
+        assertThat(ex.path).isEqualTo("null");
+    }
+
+    @DataProvider(value = {
+            "false, false",
+            "true, true"
+    })
+    @Test
+    public void two_arg_constructor_works_as_expected(boolean nullMethod, boolean nullEndpoint) {
+        // given
+        RequestInfo<?> requestInfo = mock(RequestInfo.class);
+        doReturn("/path").when(requestInfo).getPath();
+        Endpoint<String> endpoint = new MissingRequiredContentExceptionTest.TestEndpoint();
+        if (nullEndpoint) {
+            endpoint = null;
+        }
+        if (!nullMethod) {
+            doReturn(HttpMethod.POST).when(requestInfo).getMethod();
+        }
+
+        // when
+        MissingRequiredContentException ex = new MissingRequiredContentException(requestInfo, endpoint);
+
+        // then
+        assertThat(ex.path).isEqualTo("/path");
+        if (nullMethod) {
+            assertThat(ex.method).isEqualTo("null");
+        } else {
+            assertThat(ex.method).isEqualTo("POST");
+        }
+        if (nullEndpoint) {
+            assertThat(ex.endpointClassName).isEqualTo("null");
+        } else {
+            assertThat(ex.endpointClassName).isEqualTo("TestEndpoint");
+        }
+    }
+
+    class TestEndpoint implements Endpoint<String> {
+
+        @Override
+        public Matcher requestMatcher() {
+            return null;
+        }
+    }
+}

--- a/riposte-spi/src/test/java/com/nike/riposte/server/http/EndpointTest.java
+++ b/riposte-spi/src/test/java/com/nike/riposte/server/http/EndpointTest.java
@@ -1,14 +1,15 @@
 package com.nike.riposte.server.http;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.nike.riposte.util.Matcher;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import java.lang.reflect.Type;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
@@ -19,8 +20,8 @@ import static org.mockito.Mockito.mock;
 public class EndpointTest {
 
     @DataProvider(value = {
-        "50000  |   false",
-        "50001  |   true"
+            "50000  |   false",
+            "50001  |   true"
     }, splitBy = "\\|")
     @Test
     public void default_method_implementations_return_expected_values(int rawContentLengthBytes,
@@ -31,13 +32,52 @@ public class EndpointTest {
         doReturn(rawContentLengthBytes).when(reqMock).getRawContentLengthInBytes();
 
         // expect
-        assertThat(defaultImpl.isValidateRequestContent(null), is(true));
-        assertThat(defaultImpl.validationGroups(null), nullValue());
-        assertThat(defaultImpl.customRequestContentDeserializer(null), nullValue());
-        assertThat(defaultImpl.customResponseContentSerializer(null), nullValue());
-        assertThat(defaultImpl.requestContentType(), nullValue());
-        assertThat(defaultImpl.completableFutureTimeoutOverrideMillis(), nullValue());
-        assertThat(defaultImpl.shouldValidateAsynchronously(reqMock), is(shouldValidateAsync));
+        assertThat(defaultImpl.isValidateRequestContent(null)).isTrue();
+        assertThat(defaultImpl.validationGroups(null)).isNull();
+        assertThat(defaultImpl.customRequestContentDeserializer(null)).isNull();
+        assertThat(defaultImpl.customResponseContentSerializer(null)).isNull();
+        assertThat(defaultImpl.requestContentType()).isNull();
+        assertThat(defaultImpl.completableFutureTimeoutOverrideMillis()).isNull();
+        assertThat(defaultImpl.shouldValidateAsynchronously(reqMock)).isEqualTo(shouldValidateAsync);
     }
 
+    @DataProvider(value = {
+            "null             | false",
+            "java.lang.Void   | false",
+            "java.lang.String | true"
+    }, splitBy = "\\|")
+    @Test
+    public void isRequireRequestContent_returnsExpectedValueBasedOnRequestContentTypeValue(String inputType, boolean expectedValue) throws ClassNotFoundException {
+        // given
+        Class<?> type = inputType == null ? null : Class.forName(inputType);
+
+        // when
+        Endpoint<?> defaultImpl = getEndpointWithRequestContentType(type);
+
+        // then
+        assertThat(defaultImpl.isRequireRequestContent()).isEqualTo(expectedValue);
+    }
+
+    private Endpoint<?> getEndpointWithRequestContentType(Class<?> type) {
+        return new Endpoint<Object>() {
+            @Override
+            public Matcher requestMatcher() {
+                return null;
+            }
+
+            @Override
+            public TypeReference<Object> requestContentType() {
+                if (type == null) {
+                    return null;
+                } else {
+                    return new TypeReference<Object>() {
+                        @Override
+                        public Type getType() {
+                            return type;
+                        }
+                    };
+                }
+            }
+        };
+    }
 }


### PR DESCRIPTION
Per #81  add ability for an endpoint to require request content and throw an exception when not present. 
