### PR TITLE
Allow proxy endpoints to disable sub spans around downstream calls and trace header propagation

### DIFF
--- a/riposte-core/src/main/java/com/nike/riposte/client/asynchttp/netty/StreamingAsyncHttpClient.java
+++ b/riposte-core/src/main/java/com/nike/riposte/client/asynchttp/netty/StreamingAsyncHttpClient.java
@@ -583,6 +583,7 @@ public class StreamingAsyncHttpClient {
     public CompletableFuture<StreamingChannel> streamDownstreamCall(
         String downstreamHost, int downstreamPort, HttpRequest initialRequestChunk, boolean isSecureHttpsCall,
         boolean relaxedHttpsValidation, StreamingCallback callback, long downstreamCallTimeoutMillis,
+        boolean performSubSpanAroundDownstreamCalls,
         ChannelHandlerContext ctx
     ) {
         CompletableFuture<StreamingChannel> streamingChannel = new CompletableFuture<>();
@@ -594,8 +595,6 @@ public class StreamingAsyncHttpClient {
                                  ? downstreamHost
                                  : downstreamHost + ":" + downstreamPort;
         initialRequestChunk.headers().set(HttpHeaders.Names.HOST, hostHeaderValue);
-
-        boolean performSubSpanAroundDownstreamCalls = true;
 
         ObjectHolder<Long> beforeConnectionStartTimeNanos = new ObjectHolder<>();
         beforeConnectionStartTimeNanos.heldObject = System.nanoTime();

--- a/riposte-core/src/main/java/com/nike/riposte/client/asynchttp/netty/StreamingAsyncHttpClient.java
+++ b/riposte-core/src/main/java/com/nike/riposte/client/asynchttp/netty/StreamingAsyncHttpClient.java
@@ -583,7 +583,7 @@ public class StreamingAsyncHttpClient {
     public CompletableFuture<StreamingChannel> streamDownstreamCall(
         String downstreamHost, int downstreamPort, HttpRequest initialRequestChunk, boolean isSecureHttpsCall,
         boolean relaxedHttpsValidation, StreamingCallback callback, long downstreamCallTimeoutMillis,
-        boolean performSubSpanAroundDownstreamCalls,
+        boolean performSubSpanAroundDownstreamCalls, boolean addTracingHeadersToDownstreamCall,
         ChannelHandlerContext ctx
     ) {
         CompletableFuture<StreamingChannel> streamingChannel = new CompletableFuture<>();
@@ -664,8 +664,8 @@ public class StreamingAsyncHttpClient {
                                              ? null
                                              : distributedSpanStackToUse.peek();
 
-                // Add distributed trace headers to the downstream call if we have a current span.
-                if (spanForDownstreamCall != null) {
+                // Add distributed trace headers to the downstream call if desired and we have a current span.
+                if (addTracingHeadersToDownstreamCall && spanForDownstreamCall != null) {
                     setHeaderIfValueNotNull(initialRequestChunk, TraceHeaders.TRACE_SAMPLED,
                                             String.valueOf(spanForDownstreamCall.isSampleable()));
                     setHeaderIfValueNotNull(initialRequestChunk, TraceHeaders.TRACE_ID,

--- a/riposte-core/src/main/java/com/nike/riposte/server/handler/ProxyRouterEndpointExecutionHandler.java
+++ b/riposte-core/src/main/java/com/nike/riposte/server/handler/ProxyRouterEndpointExecutionHandler.java
@@ -186,6 +186,7 @@ public class ProxyRouterEndpointExecutionHandler extends BaseInboundHandlerWithT
                                 boolean isSecureHttpsCall = downstreamRequestFirstChunkInfo.isHttps;
                                 boolean relaxedHttpsValidation = downstreamRequestFirstChunkInfo.relaxedHttpsValidation;
                                 boolean performSubSpanAroundDownstreamCall = downstreamRequestFirstChunkInfo.performSubSpanAroundDownstreamCall;
+                                boolean addTracingHeadersToDownstreamCall = downstreamRequestFirstChunkInfo.addTracingHeadersToDownstreamCall;
 
                                 // Tell the proxyRouterState about the streaming callback so that
                                 //      callback.unrecoverableErrorOccurred(...) can be called in the case of an error
@@ -199,7 +200,7 @@ public class ProxyRouterEndpointExecutionHandler extends BaseInboundHandlerWithT
                                     streamingAsyncHttpClient.streamDownstreamCall(
                                         downstreamHost, downstreamPort, downstreamRequestFirstChunk, isSecureHttpsCall,
                                         relaxedHttpsValidation, callback, callTimeoutValueToUse,
-                                            performSubSpanAroundDownstreamCall,
+                                            performSubSpanAroundDownstreamCall, addTracingHeadersToDownstreamCall,
                                             ctx
                                     );
 

--- a/riposte-core/src/main/java/com/nike/riposte/server/handler/ProxyRouterEndpointExecutionHandler.java
+++ b/riposte-core/src/main/java/com/nike/riposte/server/handler/ProxyRouterEndpointExecutionHandler.java
@@ -185,6 +185,7 @@ public class ProxyRouterEndpointExecutionHandler extends BaseInboundHandlerWithT
                                 HttpRequest downstreamRequestFirstChunk = downstreamRequestFirstChunkInfo.firstChunk;
                                 boolean isSecureHttpsCall = downstreamRequestFirstChunkInfo.isHttps;
                                 boolean relaxedHttpsValidation = downstreamRequestFirstChunkInfo.relaxedHttpsValidation;
+                                boolean performSubSpanAroundDownstreamCall = downstreamRequestFirstChunkInfo.performSubSpanAroundDownstreamCall;
 
                                 // Tell the proxyRouterState about the streaming callback so that
                                 //      callback.unrecoverableErrorOccurred(...) can be called in the case of an error
@@ -197,8 +198,9 @@ public class ProxyRouterEndpointExecutionHandler extends BaseInboundHandlerWithT
                                 CompletableFuture<StreamingChannel> streamingChannel =
                                     streamingAsyncHttpClient.streamDownstreamCall(
                                         downstreamHost, downstreamPort, downstreamRequestFirstChunk, isSecureHttpsCall,
-                                        relaxedHttpsValidation, callback,
-                                        callTimeoutValueToUse, ctx
+                                        relaxedHttpsValidation, callback, callTimeoutValueToUse,
+                                            performSubSpanAroundDownstreamCall,
+                                            ctx
                                     );
 
                                 // Tell the streaming channel future what to do when it completes.

--- a/riposte-core/src/main/java/com/nike/riposte/server/http/ProxyRouterEndpoint.java
+++ b/riposte-core/src/main/java/com/nike/riposte/server/http/ProxyRouterEndpoint.java
@@ -185,6 +185,10 @@ public abstract class ProxyRouterEndpoint implements Endpoint {
          * Set this to false if you do not want a SubSpan around your proxied downstream call
          */
         public boolean performSubSpanAroundDownstreamCall = true;
+        /**
+         * Set this to false if you do not want the standard tracing headers to be added to your downstream call
+         */
+        public boolean addTracingHeadersToDownstreamCall = true;
 
         /**
          * Creates a new instance with the given values, and defaults {@link #customCircuitBreaker} to {@link
@@ -248,6 +252,14 @@ public abstract class ProxyRouterEndpoint implements Endpoint {
          */
         public DownstreamRequestFirstChunkInfo withPerformSubSpanAroundDownstreamCall(boolean performSubSpanAroundDownstreamCall) {
             this.performSubSpanAroundDownstreamCall = performSubSpanAroundDownstreamCall;
+            return this;
+        }
+
+        /**
+         * Pass in false if you do not want the standard tracing headers added to your downstream call
+         */
+        public DownstreamRequestFirstChunkInfo withAddTracingHeadersToDownstreamCall(boolean addTracingHeadersToDownstreamCall) {
+            this.addTracingHeadersToDownstreamCall = addTracingHeadersToDownstreamCall;
             return this;
         }
     }

--- a/riposte-core/src/main/java/com/nike/riposte/server/http/ProxyRouterEndpoint.java
+++ b/riposte-core/src/main/java/com/nike/riposte/server/http/ProxyRouterEndpoint.java
@@ -181,6 +181,10 @@ public abstract class ProxyRouterEndpoint implements Endpoint {
          * security vulnerabilities - make sure you know what you're doing.
          */
         public boolean relaxedHttpsValidation = false;
+        /**
+         * Set this to false if you do not want a SubSpan around your proxied downstream call
+         */
+        public boolean performSubSpanAroundDownstreamCall = true;
 
         /**
          * Creates a new instance with the given values, and defaults {@link #customCircuitBreaker} to {@link
@@ -236,6 +240,14 @@ public abstract class ProxyRouterEndpoint implements Endpoint {
          */
         public DownstreamRequestFirstChunkInfo withRelaxedHttpsValidation(boolean relaxedHttpsValidation) {
             this.relaxedHttpsValidation = relaxedHttpsValidation;
+            return this;
+        }
+
+        /**
+         * Pass in false if you do not want SubSpans created around your downstream call
+         */
+        public DownstreamRequestFirstChunkInfo withPerformSubSpanAroundDownstreamCall(boolean performSubSpanAroundDownstreamCall) {
+            this.performSubSpanAroundDownstreamCall = performSubSpanAroundDownstreamCall;
             return this;
         }
     }

--- a/riposte-core/src/test/java/com/nike/riposte/client/asynchttp/netty/StreamingAsyncHttpClientTest.java
+++ b/riposte-core/src/test/java/com/nike/riposte/client/asynchttp/netty/StreamingAsyncHttpClientTest.java
@@ -3,24 +3,48 @@ package com.nike.riposte.client.asynchttp.netty;
 import com.nike.riposte.client.asynchttp.netty.StreamingAsyncHttpClient.ObjectHolder;
 import com.nike.riposte.client.asynchttp.netty.StreamingAsyncHttpClient.StreamingCallback;
 import com.nike.riposte.client.asynchttp.netty.StreamingAsyncHttpClient.StreamingChannel;
+import com.nike.riposte.server.Server;
 import com.nike.riposte.server.channelpipeline.ChannelAttributes;
+import com.nike.riposte.server.componenttest.VerifyResponseHttpStatusCodeHandlingRfcCorrectnessComponentTest;
+import com.nike.riposte.server.config.ServerConfig;
+import com.nike.riposte.server.http.Endpoint;
 import com.nike.riposte.server.http.HttpProcessingState;
+import com.nike.riposte.server.http.RequestInfo;
+import com.nike.riposte.server.http.ResponseInfo;
+import com.nike.riposte.server.http.StandardEndpoint;
+import com.nike.riposte.server.testutils.ComponentTestUtils;
+import com.nike.riposte.server.testutils.TestUtil;
+import com.nike.riposte.util.Matcher;
 import com.nike.wingtips.Span;
 
+import com.nike.wingtips.TraceHeaders;
+import com.nike.wingtips.Tracer;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
+import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 
+import java.io.IOException;
+import java.security.cert.CertificateException;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
@@ -35,6 +59,7 @@ import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 
 import static com.nike.riposte.client.asynchttp.netty.StreamingAsyncHttpClient.CHANNEL_IS_BROKEN_ATTR;
+import static com.nike.wingtips.Span.SpanPurpose.SERVER;
 import static io.netty.handler.codec.http.HttpHeaders.Names.HOST;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -74,6 +99,10 @@ public class StreamingAsyncHttpClientTest {
 
     private ChannelFuture failedFutureMock;
 
+    private static Server backendServer;
+    private static ServerConfig backendServerConfig;
+    private static int backendServerPort;
+
     @Before
     public void beforeMethod() {
         channelMock = mock(Channel.class);
@@ -105,6 +134,20 @@ public class StreamingAsyncHttpClientTest {
 
         failedFutureMock = mock(ChannelFuture.class);
         doReturn(failedFutureMock).when(channelMock).newFailedFuture(any(Throwable.class));
+    }
+
+    @BeforeClass
+    public static void startupServer() throws IOException, CertificateException, InterruptedException {
+        backendServerPort = ComponentTestUtils.findFreePort();
+        backendServerConfig = new BackendServerConfig(backendServerPort);
+        backendServer = new Server(backendServerConfig);
+        backendServer.startup();
+    }
+
+    @AfterClass
+    public static void stopServer() throws InterruptedException {
+        backendServerPort = -1;
+        backendServer.shutdown();
     }
 
     @Test
@@ -432,25 +475,54 @@ public class StreamingAsyncHttpClientTest {
     public void streamDownstreamCall_setsHostHeaderCorrectly(int downstreamPort, boolean isSecure, String downstreamHost, String expectedHostHeader) {
         // given
         DefaultHttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "");
-        ChannelHandlerContext ctx = mockChannelHandlerContext();
+        ChannelHandlerContext ctx = TestUtil.mockChannelHandlerContext().mockContext;
         StreamingCallback streamingCallback = mock(StreamingCallback.class);
 
         // when
         new StreamingAsyncHttpClient(200, 200, true)
-                .streamDownstreamCall(downstreamHost, downstreamPort, request, isSecure, false, streamingCallback, 200, ctx);
+                .streamDownstreamCall(downstreamHost, downstreamPort, request, isSecure, false, streamingCallback, 200, true, ctx);
 
         // then
         assertThat(request.headers().get(HOST)).isEqualTo(expectedHostHeader);
     }
 
-    private ChannelHandlerContext mockChannelHandlerContext() {
-        ChannelHandlerContext mockContext = mock(ChannelHandlerContext.class);
-        when(mockContext.channel()).thenReturn(mock(Channel.class));
-        @SuppressWarnings("unchecked")
-        Attribute<HttpProcessingState> mockAttribute = mock(Attribute.class);
-        when(mockContext.channel().attr(ChannelAttributes.HTTP_PROCESSING_STATE_ATTRIBUTE_KEY)).thenReturn(mockAttribute);
-        when(mockContext.channel().attr(ChannelAttributes.HTTP_PROCESSING_STATE_ATTRIBUTE_KEY).get()).thenReturn(mock(HttpProcessingState.class));
-        return mockContext;
+    @DataProvider(value = {
+            "false",
+            "true"
+    }, splitBy = "\\|")
+    @Test
+    public void streamDownstreamCall_createsSubSpanAroundDownstreamCallBasedOnFlag(boolean performSubSpanAroundDownstreamCalls) throws InterruptedException, ExecutionException {
+        // given
+        DefaultHttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "");
+        ChannelHandlerContext ctx = TestUtil.mockChannelHandlerContextWithTraceInfo().mockContext;
+        StreamingCallback streamingCallback = mock(StreamingCallback.class);
+        Span currentSpan = Tracer.getInstance().getCurrentSpan();
+
+        // when
+        new StreamingAsyncHttpClient(200, 200, true)
+                .streamDownstreamCall("localhost", backendServerPort, request, false, false, streamingCallback, 200, performSubSpanAroundDownstreamCalls, ctx).get();
+
+        // then
+        if (performSubSpanAroundDownstreamCalls) {
+            assertThat(request.headers().get(TraceHeaders.TRACE_SAMPLED)).isEqualTo(String.valueOf(currentSpan.isSampleable())); // should match
+            assertThat(request.headers().get(TraceHeaders.TRACE_ID)).isEqualTo(currentSpan.getTraceId()); // should match
+            assertThat(request.headers().get(TraceHeaders.SPAN_ID)).isNotEqualTo(currentSpan.getSpanId()); // should have generated a new one
+            assertThat(request.headers().get(TraceHeaders.PARENT_SPAN_ID)).isEqualTo(currentSpan.getSpanId()); // parent equals our starting spanId
+            assertThat(request.headers().get(TraceHeaders.SPAN_NAME)).isEqualTo("async_downstream_call-GET_localhost:" + backendServerPort); // generated span name for new SubSpan
+        } else {
+            assertDefaultTraceHeadersWereAddedToRequest(request, currentSpan);
+        }
+
+        // cleanup after this test
+        Tracer.getInstance().completeRequestSpan();
+    }
+
+    private void assertDefaultTraceHeadersWereAddedToRequest(DefaultHttpRequest request, Span currentSpan) {
+        assertThat(request.headers().get(TraceHeaders.TRACE_SAMPLED)).isEqualTo(String.valueOf(currentSpan.isSampleable()));
+        assertThat(request.headers().get(TraceHeaders.TRACE_ID)).isEqualTo(currentSpan.getTraceId());
+        assertThat(request.headers().get(TraceHeaders.SPAN_ID)).isEqualTo(currentSpan.getSpanId());
+        assertThat(request.headers().get(TraceHeaders.PARENT_SPAN_ID)).isNullOrEmpty(); // no parent since only request span is started
+        assertThat(request.headers().get(TraceHeaders.SPAN_NAME)).isEqualTo("mockChannelHandlerContext");
     }
 
     private void verifyChannelReleasedBackToPool(ObjectHolder<Boolean> callActiveHolder,
@@ -460,4 +532,49 @@ public class StreamingAsyncHttpClientTest {
         verify(theChannelPoolMock).release(theChannelMock);
     }
 
+    public static class BackendServerConfig implements ServerConfig {
+        private final int port;
+        private final Endpoint<?> backendEndpoint;
+
+        public BackendServerConfig(int port) {
+            this.port = port;
+            this.backendEndpoint = new BackendEndpoint();
+        }
+
+        @Override
+        public Collection<Endpoint<?>> appEndpoints() {
+            return Collections.singleton(backendEndpoint);
+        }
+
+        @Override
+        public int endpointsPort() {
+            return port;
+        }
+
+        @Override
+        public long workerChannelIdleTimeoutMillis() {
+            return -1;
+        }
+    }
+
+    public static class BackendEndpoint extends StandardEndpoint<Void, String> {
+
+        public static final String MATCHING_PATH = "/";
+
+        @Override
+        public CompletableFuture<ResponseInfo<String>> execute(RequestInfo<Void> request, Executor longRunningTaskExecutor, ChannelHandlerContext ctx) {
+            return CompletableFuture.completedFuture(
+                    ResponseInfo.newBuilder("{\"success\":true}")
+                            .withHttpStatusCode(200)
+                            .withDesiredContentWriterMimeType("application/json")
+                            .build()
+            );
+        }
+
+        @Override
+        public Matcher requestMatcher() {
+            return Matcher.match(MATCHING_PATH, HttpMethod.GET);
+        }
+
+    }
 }

--- a/riposte-core/src/test/java/com/nike/riposte/server/http/ProxyRouterEndpointTest.java
+++ b/riposte-core/src/test/java/com/nike/riposte/server/http/ProxyRouterEndpointTest.java
@@ -1,15 +1,22 @@
 package com.nike.riposte.server.http;
 
+import com.nike.riposte.server.http.ProxyRouterEndpoint.DownstreamRequestFirstChunkInfo;
 import com.nike.riposte.util.Matcher;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.HttpRequest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
+@RunWith(DataProviderRunner.class)
 public class ProxyRouterEndpointTest {
 
     ProxyRouterEndpoint defaultImpl;
@@ -42,5 +49,68 @@ public class ProxyRouterEndpointTest {
     @Test
     public void requestContentType_returnsNull() {
         assertThat(defaultImpl.requestContentType()).isNull();
+    }
+
+    @Test
+    public void downstreamRequestFirstChunkInfo_constructorSetsValuesAsExpected() {
+        // given
+        HttpRequest firstChunk = mock(HttpRequest.class);
+
+        // when
+        DownstreamRequestFirstChunkInfo downstreamRequestFirstChunkInfo = new DownstreamRequestFirstChunkInfo("localhost", 8080, true, firstChunk);
+
+        // then
+        assertThat(downstreamRequestFirstChunkInfo.host).isEqualTo("localhost");
+        assertThat(downstreamRequestFirstChunkInfo.port).isEqualTo(8080);
+        assertThat(downstreamRequestFirstChunkInfo.isHttps).isTrue();
+        assertThat(downstreamRequestFirstChunkInfo.relaxedHttpsValidation).isFalse();
+        assertThat(downstreamRequestFirstChunkInfo.firstChunk).isEqualTo(firstChunk);
+        assertThat(downstreamRequestFirstChunkInfo.addTracingHeadersToDownstreamCall).isTrue();
+        assertThat(downstreamRequestFirstChunkInfo.performSubSpanAroundDownstreamCall).isTrue();
+    }
+
+    @Test
+    @DataProvider(value = {
+            "true",
+            "false"
+    }, splitBy = "\\|")
+    public void downstreamRequestFirstChunkInfo_allowsOverrideOfRelaxHttpsValidationFlag(boolean flagValue) {
+        // when
+        DownstreamRequestFirstChunkInfo downstreamRequestFirstChunkInfo =
+                new DownstreamRequestFirstChunkInfo("localhost", 8080, true, null)
+                        .withRelaxedHttpsValidation(flagValue);
+
+        // then
+        assertThat(downstreamRequestFirstChunkInfo.relaxedHttpsValidation).isEqualTo(flagValue);
+    }
+
+    @Test
+    @DataProvider(value = {
+            "true",
+            "false"
+    }, splitBy = "\\|")
+    public void downstreamRequestFirstChunkInfo_allowsOverrideOfAddTracingFlag(boolean flagValue) {
+        // when
+        DownstreamRequestFirstChunkInfo downstreamRequestFirstChunkInfo =
+                new DownstreamRequestFirstChunkInfo("localhost", 8080, true, null)
+                .withAddTracingHeadersToDownstreamCall(flagValue);
+
+        // then
+        assertThat(downstreamRequestFirstChunkInfo.addTracingHeadersToDownstreamCall).isEqualTo(flagValue);
+    }
+
+    @Test
+    @DataProvider(value = {
+            "true",
+            "false"
+    }, splitBy = "\\|")
+    public void downstreamRequestFirstChunkInfo_allowsOverrideOfPerformSubspanOnDownstreamCall(boolean flagValue) {
+        // when
+        DownstreamRequestFirstChunkInfo downstreamRequestFirstChunkInfo =
+                new DownstreamRequestFirstChunkInfo("localhost", 8080, true, null)
+                        .withPerformSubSpanAroundDownstreamCall(flagValue);
+
+        // then
+        assertThat(downstreamRequestFirstChunkInfo.performSubSpanAroundDownstreamCall).isEqualTo(flagValue);
     }
 }


### PR DESCRIPTION
Currently all proxy endpoints create a subspan around the downstream call and propagate all trace headers by default on every request

This PR adds the following two abilities
* allows an endpoint to configure a request to turn off trace header propagation 
* allows an endpoint to configure a request to not create a subspan around the downstream call

Default for these features is existing behavior, so this is a backwards compatible enhancement