### PR TITLE
Build on Java 11

### DIFF
--- a/samples/sample-2-kotlin-todoservice/build.gradle
+++ b/samples/sample-2-kotlin-todoservice/build.gradle
@@ -1,8 +1,6 @@
 evaluationDependsOn(':')
 
 ext {
-    kotlinTestVersion = '2.0.5'
-    googleTruthVersion = '0.34'
 }
 
 buildscript {
@@ -42,9 +40,8 @@ dependencies {
     )
     testCompile (
             "org.jetbrains:annotations:$jetbrainsAnnotationsVersion",
-            "io.rest-assured:rest-assured:$restAssuredVersion",
-            "io.kotlintest:kotlintest:$kotlinTestVersion",
-            "com.google.truth:truth:${googleTruthVersion}"
+            "junit:junit:$junitVersion",
+            "io.rest-assured:rest-assured:$restAssuredVersion"
     )
 }
 

--- a/samples/sample-2-kotlin-todoservice/src/test/kotlin/com/nike/todoservice/TodoEndpointTest.kt
+++ b/samples/sample-2-kotlin-todoservice/src/test/kotlin/com/nike/todoservice/TodoEndpointTest.kt
@@ -1,90 +1,20 @@
 package com.nike.todoservice
 
-import com.google.common.truth.Truth
 import com.nike.riposte.server.Server
-import io.kotlintest.ProjectConfig
-import io.kotlintest.specs.FeatureSpec
 import io.restassured.RestAssured.given
 import io.restassured.http.ContentType.JSON
 import io.restassured.specification.RequestSpecification
+import org.junit.Assert.assertEquals
 import org.junit.AfterClass
 import org.junit.BeforeClass
+import org.junit.FixMethodOrder
+import org.junit.Test
+import org.junit.runners.MethodSorters
 import java.io.IOException
 import java.net.ServerSocket
 
-class TodoEndpointTest : FeatureSpec()  {
-
-    class AppServerConfigForTesting(private val port: Int) : AppServerConfig() {
-        override fun endpointsPort(): Int {
-            return port
-        }
-    }
-
-    init {
-
-        feature("Operations to create/modify TODO Items") {
-
-            scenario("A TODO Item is created successfully") {
-                val response =
-                        given()
-                            .port(serverConfig!!.endpointsPort())
-                            .request().contentType("application/json")
-                            .body(postPayload)
-                        .When()
-                            .post(path)
-                        .then()
-                            .statusCode(201)
-                            .contentType(JSON)
-                            .extract()
-                val todoRecord = response.`as`(TodoRecord::class.java)
-                todoIdCreated = todoRecord.id?:0
-                Truth.assertThat(todoRecord.name).isEqualTo("TaskOne")
-                Truth.assertThat(todoRecord.task).isEqualTo("My first task")
-            }
-
-            scenario("A TODO Item can be queried successfully") {
-                val response = given()
-                            .port(serverConfig!!.endpointsPort())
-                            .request()
-                            .contentType("application/json")
-                        .When()
-                            .pathParam("todoId", todoIdCreated)
-                            .get(pathWithParam )
-                        .then()
-                            .statusCode(200)
-                            .contentType(JSON).extract()
-                val todoRecord = response.`as`(TodoRecord::class.java)
-                Truth.assertThat(todoRecord.name).isEqualTo("TaskOne")
-                Truth.assertThat(todoRecord.task).isEqualTo("My first task")
-            }
-
-            scenario("A TODO Item can be updated") {
-                val response = given()
-                        .port(serverConfig!!.endpointsPort())
-                        .request().contentType("application/json")
-                    .When().pathParam("todoId", todoIdCreated)
-                        .body(putPayload(todoIdCreated))
-                        .put(pathWithParam )
-                    .then().statusCode(200).contentType(JSON).extract()
-                val todoRecord = response.`as`(TodoRecord::class.java)
-                Truth.assertThat(todoRecord.name).isEqualTo("TaskTwo")
-                Truth.assertThat(todoRecord.task).isEqualTo("My New task")
-            }
-
-            scenario("A TODO Item can be deleted") {
-                given()
-                        .port(serverConfig!!.endpointsPort())
-                        .request().contentType("application/json")
-                .When()
-                        .pathParam("todoId", todoIdCreated)
-                        .delete(pathWithParam )
-                .then()
-                        .statusCode(204)
-                        .contentType(JSON)
-            }
-        }
-    }
-
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+class TodoEndpointTest {
     companion object {
         data class TodoRecord(val id: Long?, val name: String, val task: String)
         val path = "/todos"
@@ -95,43 +25,106 @@ class TodoEndpointTest : FeatureSpec()  {
         private var serverConfig: AppServerConfigForTesting? = null
         var todoIdCreated: Long = 0
 
-        object TodoEndpointConfig : ProjectConfig() {
-            private var started: Long = 0
-            override fun beforeAll() {
-                started = System.currentTimeMillis()
-                println(" Starting Riposte !!!")
-                setup()
-            }
-            override fun afterAll() {
-                val time = System.currentTimeMillis() - started
-                println("overall time [ms]: " + time)
-                teardown()
-            }
-        }
-
         @Throws(IOException::class)
         private fun findFreePort(): Int {
             ServerSocket(0).use { serverSocket -> return serverSocket.localPort }
         }
 
-        @BeforeClass
-        @Throws(Exception::class)
-        fun setup() {
+        @BeforeClass @JvmStatic fun setup() {
             serverConfig = AppServerConfigForTesting(findFreePort())
             server = Server(serverConfig!!)
             server!!.startup()
         }
 
-        @AfterClass
-        @Throws(Exception::class)
-        fun teardown() {
+        @AfterClass @JvmStatic fun teardown() {
             server!!.shutdown()
         }
-
     }
+
+
+    @Test
+    fun `1 A TODO Item is created successfully`() {
+        val response =
+                given()
+                    .port(serverConfig!!.endpointsPort())
+                    .request().contentType("application/json")
+                    .body(postPayload)
+                .When()
+                    .post(path)
+                .then()
+                    .statusCode(201)
+                    .contentType(JSON)
+                    .extract()
+
+        val todoRecord = response.`as`(TodoRecord::class.java)
+        todoIdCreated = todoRecord.id?:0
+
+        assertEquals("TaskOne", todoRecord.name)
+        assertEquals("My first task", todoRecord.task)
+    }
+
+
+    @Test
+    fun `2 A TODO Item can be queried successfully`() {
+        val response =
+                given()
+                    .port(serverConfig!!.endpointsPort())
+                    .request()
+                    .contentType("application/json")
+                .When()
+                    .pathParam("todoId", todoIdCreated)
+                    .get(pathWithParam )
+                .then()
+                    .statusCode(200)
+                    .contentType(JSON).extract()
+
+        val todoRecord = response.`as`(TodoRecord::class.java)
+        assertEquals("TaskOne", todoRecord.name)
+        assertEquals("My first task", todoRecord.task)
+    }
+
+
+    @Test
+    fun `3 A TODO Item can be updated`() {
+        val response =
+                given()
+                        .port(serverConfig!!.endpointsPort())
+                        .request().contentType("application/json")
+                .When()
+                        .pathParam("todoId", todoIdCreated)
+                        .body(putPayload(todoIdCreated))
+                        .put(pathWithParam )
+                .then()
+                        .statusCode(200).contentType(JSON).extract()
+
+        val todoRecord = response.`as`(TodoRecord::class.java)
+        assertEquals("TaskTwo", todoRecord.name)
+        assertEquals("My New task", todoRecord.task)
+    }
+
+
+    @Test
+    fun `4 A TODO Item can be deleted`() {
+        given()
+                .port(serverConfig!!.endpointsPort())
+                .request().contentType("application/json")
+        .When()
+                .pathParam("todoId", todoIdCreated)
+                .delete(pathWithParam )
+        .then()
+                .statusCode(204)
+                .contentType(JSON)
+    }
+
     //https://github.com/rest-assured/rest-assured/wiki/Usage#kotlin
     fun RequestSpecification.When(): RequestSpecification {
         return this.`when`()
     }
 
+
+    class AppServerConfigForTesting(private val port: Int) : AppServerConfig() {
+        override fun endpointsPort(): Int {
+            return port
+        }
+    }
 }


### PR DESCRIPTION
- Upgrade to Gradle 4.10.2
- Upgrade to RestAssured 3.2.0
- Upgrade to Jacoco 0.8.2
- sample-2-kotlin-todoservice:
  - Upgrade Kotlin version to 1.2.70
  - Replace @BeforeClass/@AfterClass annotations with interceptor
    because annotated methods didn't run under OpenJDK 11

Fixes #109. Build and unit tests work on both Java 8 and Java 11