### PR TITLE
upgrade asyncHttpClient from ning (1.x) to 2.x version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ ext {
     objenesisVersion = '2.1'
     javassistVersion = '3.18.2-GA'
     jacksonVersion = '2.8.9'
-    ningAsyncHttpClientVersion = '1.9.38'
+    asyncHttpClientVersion = '2.6.0'
     guiceVersion = '4.0'
 
     jodaTimeVersion = '2.9.2'

--- a/riposte-async-http-client/build.gradle
+++ b/riposte-async-http-client/build.gradle
@@ -3,7 +3,7 @@ evaluationDependsOn(':')
 dependencies {
     compile(
             project(":riposte-core"),
-            "com.ning:async-http-client:$ningAsyncHttpClientVersion"
+            "org.asynchttpclient:async-http-client:$asyncHttpClientVersion"
     )
 
     testCompile (

--- a/riposte-async-http-client/src/main/java/com/nike/riposte/client/asynchttp/AsyncCompletionHandlerWithTracingAndMdcSupport.java
+++ b/riposte-async-http-client/src/main/java/com/nike/riposte/client/asynchttp/AsyncCompletionHandlerWithTracingAndMdcSupport.java
@@ -1,4 +1,4 @@
-package com.nike.riposte.client.asynchttp.ning;
+package com.nike.riposte.client.asynchttp;
 
 import com.nike.fastbreak.CircuitBreaker;
 import com.nike.internal.util.Pair;
@@ -6,9 +6,8 @@ import com.nike.riposte.util.AsyncNettyHelper;
 import com.nike.wingtips.Span;
 import com.nike.wingtips.Tracer;
 
-import com.ning.http.client.AsyncCompletionHandler;
-import com.ning.http.client.Response;
-
+import org.asynchttpclient.AsyncCompletionHandler;
+import org.asynchttpclient.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -21,13 +20,13 @@ import java.util.concurrent.CompletableFuture;
 import static com.nike.riposte.util.AsyncNettyHelper.linkTracingAndMdcToCurrentThread;
 
 /**
- * Extension of {@link com.ning.http.client.AsyncCompletionHandler} that handles distributed tracing and MDC issues so
+ * Extension of {@link org.asynchttpclient.AsyncCompletionHandler} that handles distributed tracing and MDC issues so
  * that the dtrace and MDC info you want are attached to the thread performing the work for the downstream call. The
  * {@link #completableFutureResponse} you pass in will be completed or completed exceptionally depending on the result
  * of the downstream call, and it will be completed with the result of the {@link #responseHandlerFunction} you pass
  * in.
  * <p/>
- * Used by {@link com.nike.riposte.client.asynchttp.ning.AsyncHttpClientHelper}
+ * Used by {@link AsyncHttpClientHelper}
  *
  * @author Nic Munroe
  */

--- a/riposte-async-http-client/src/main/java/com/nike/riposte/client/asynchttp/AsyncResponseHandler.java
+++ b/riposte-async-http-client/src/main/java/com/nike/riposte/client/asynchttp/AsyncResponseHandler.java
@@ -1,6 +1,6 @@
-package com.nike.riposte.client.asynchttp.ning;
+package com.nike.riposte.client.asynchttp;
 
-import com.ning.http.client.Response;
+import org.asynchttpclient.Response;
 
 /**
  * Interface representing a handler for an async downstream HTTP call's response. Used by {@link AsyncHttpClientHelper}.

--- a/riposte-async-http-client/src/main/java/com/nike/riposte/client/asynchttp/RequestBuilderWrapper.java
+++ b/riposte-async-http-client/src/main/java/com/nike/riposte/client/asynchttp/RequestBuilderWrapper.java
@@ -1,14 +1,12 @@
-package com.nike.riposte.client.asynchttp.ning;
+package com.nike.riposte.client.asynchttp;
 
 import com.nike.fastbreak.CircuitBreaker;
-
-import com.ning.http.client.AsyncHttpClient;
-import com.ning.http.client.Response;
-
-import java.util.Optional;
-
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpMethod;
+import org.asynchttpclient.BoundRequestBuilder;
+import org.asynchttpclient.Response;
+
+import java.util.Optional;
 
 /**
  * Wrapper around the actual {@link #requestBuilder} that also keeps track of the URL and HTTP method used to create the
@@ -26,7 +24,7 @@ public class RequestBuilderWrapper {
 
     String url;
     String httpMethod;
-    public final AsyncHttpClient.BoundRequestBuilder requestBuilder;
+    public final BoundRequestBuilder requestBuilder;
     /**
      * An Optional containing a custom circuit breaker if a custom one should be used, or empty if the request sender
      * should use a default circuit breaker. If you don't want *any* circuit breaker to be used, set {@link
@@ -49,7 +47,7 @@ public class RequestBuilderWrapper {
      * AsyncHttpClientHelper#getRequestBuilder(String, HttpMethod)}.
      */
     RequestBuilderWrapper(
-        String url, String httpMethod, AsyncHttpClient.BoundRequestBuilder requestBuilder,
+        String url, String httpMethod, BoundRequestBuilder requestBuilder,
         Optional<CircuitBreaker<Response>> customCircuitBreaker, boolean disableCircuitBreaker
     ) {
         this.url = url;
@@ -85,9 +83,9 @@ public class RequestBuilderWrapper {
 
     /**
      * <p>Use this method to update the url stored inside this {@link RequestBuilderWrapper}
-     * and the wrapped {@link AsyncHttpClient.BoundRequestBuilder}
+     * and the wrapped {@link BoundRequestBuilder}
      *
-     * <p>Setting the url only on the wrapped {@link AsyncHttpClient.BoundRequestBuilder} will impact logging
+     * <p>Setting the url only on the wrapped {@link BoundRequestBuilder} will impact logging
      * and circuit breakers potentially. Use this method to keep the two in sync.
      */
     public void setUrl(String url) {
@@ -101,9 +99,9 @@ public class RequestBuilderWrapper {
 
     /**
      * <p>Use this method to update the httpMethod stored inside this {@link RequestBuilderWrapper}
-     * and the wrapped {@link AsyncHttpClient.BoundRequestBuilder}
+     * and the wrapped {@link BoundRequestBuilder}
      *
-     * <p>Setting the httpMethod only on the wrapped {@link AsyncHttpClient.BoundRequestBuilder} will impact logging
+     * <p>Setting the httpMethod only on the wrapped {@link BoundRequestBuilder} will impact logging
      * and circuit breakers potentially. Use this method to keep the two in sync.
      */
     public void setHttpMethod(String httpMethod) {

--- a/riposte-async-http-client/src/main/java/com/nike/riposte/util/AwsUtil.java
+++ b/riposte-async-http-client/src/main/java/com/nike/riposte/util/AwsUtil.java
@@ -1,13 +1,13 @@
 package com.nike.riposte.util;
 
-import com.nike.riposte.client.asynchttp.ning.AsyncHttpClientHelper;
+import com.nike.riposte.client.asynchttp.AsyncHttpClientHelper;
 import com.nike.riposte.server.config.AppInfo;
 import com.nike.riposte.server.config.impl.AppInfoImpl;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.ning.http.client.Response;
 
+import org.asynchttpclient.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/riposte-async-http-client/src/test/java/com/nike/riposte/client/asynchttp/AsyncCompletionHandlerWithTracingAndMdcSupportTest.java
+++ b/riposte-async-http-client/src/test/java/com/nike/riposte/client/asynchttp/AsyncCompletionHandlerWithTracingAndMdcSupportTest.java
@@ -1,4 +1,4 @@
-package com.nike.riposte.client.asynchttp.ning;
+package com.nike.riposte.client.asynchttp;
 
 import com.nike.fastbreak.CircuitBreaker;
 import com.nike.fastbreak.CircuitBreaker.ManualModeTask;
@@ -6,10 +6,10 @@ import com.nike.internal.util.Pair;
 import com.nike.wingtips.Span;
 import com.nike.wingtips.Tracer;
 
-import com.ning.http.client.Response;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 
+import org.asynchttpclient.Response;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -25,7 +25,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
-import static com.nike.riposte.client.asynchttp.ning.AsyncCompletionHandlerWithTracingAndMdcSupportTest.ExistingSpanStackState.EMPTY;
+import static com.nike.riposte.client.asynchttp.AsyncCompletionHandlerWithTracingAndMdcSupportTest.ExistingSpanStackState.EMPTY;
 import static java.lang.Boolean.TRUE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;

--- a/riposte-async-http-client/src/test/java/com/nike/riposte/client/asynchttp/RequestBuilderWrapperTest.java
+++ b/riposte-async-http-client/src/test/java/com/nike/riposte/client/asynchttp/RequestBuilderWrapperTest.java
@@ -1,11 +1,11 @@
-package com.nike.riposte.client.asynchttp.ning;
+package com.nike.riposte.client.asynchttp;
 
 import com.nike.fastbreak.CircuitBreaker;
 import com.nike.fastbreak.CircuitBreakerImpl;
-import com.ning.http.client.AsyncHttpClient;
-import com.ning.http.client.Response;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpMethod;
+import org.asynchttpclient.BoundRequestBuilder;
+import org.asynchttpclient.Response;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -21,7 +21,7 @@ public class RequestBuilderWrapperTest {
     private RequestBuilderWrapper requestBuilderWrapper;
     private String url;
     private String httpMethod;
-    private AsyncHttpClient.BoundRequestBuilder requestBuilder;
+    private BoundRequestBuilder requestBuilder;
     private Optional<CircuitBreaker<Response>> customCircuitBreaker;
     private boolean disableCircuitBreaker;
 
@@ -29,7 +29,7 @@ public class RequestBuilderWrapperTest {
     public void setup() {
         url = "http://localhost.com";
         httpMethod = HttpMethod.GET.name();
-        requestBuilder = mock(AsyncHttpClient.BoundRequestBuilder.class);
+        requestBuilder = mock(BoundRequestBuilder.class);
         customCircuitBreaker = Optional.of(new CircuitBreakerImpl<Response>());
         disableCircuitBreaker = true;
     }

--- a/riposte-async-http-client/src/test/java/com/nike/riposte/componenttest/VerifyAsyncHttpClientHelperComponentTest.java
+++ b/riposte-async-http-client/src/test/java/com/nike/riposte/componenttest/VerifyAsyncHttpClientHelperComponentTest.java
@@ -3,8 +3,8 @@ package com.nike.riposte.componenttest;
 import com.nike.backstopper.apierror.ApiError;
 import com.nike.backstopper.apierror.ApiErrorBase;
 import com.nike.backstopper.exception.ApiException;
-import com.nike.riposte.client.asynchttp.ning.AsyncHttpClientHelper;
-import com.nike.riposte.client.asynchttp.ning.RequestBuilderWrapper;
+import com.nike.riposte.client.asynchttp.AsyncHttpClientHelper;
+import com.nike.riposte.client.asynchttp.RequestBuilderWrapper;
 import com.nike.riposte.server.Server;
 import com.nike.riposte.server.config.ServerConfig;
 import com.nike.riposte.server.http.Endpoint;
@@ -16,8 +16,8 @@ import com.nike.wingtips.Span;
 import com.nike.wingtips.TraceHeaders;
 import com.nike.wingtips.Tracer;
 
-import com.ning.http.client.Response;
 
+import org.asynchttpclient.Response;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;

--- a/riposte-async-http-client/src/test/java/com/nike/riposte/util/AwsUtilTest.java
+++ b/riposte-async-http-client/src/test/java/com/nike/riposte/util/AwsUtilTest.java
@@ -1,16 +1,16 @@
 package com.nike.riposte.util;
 
 import com.nike.internal.util.Pair;
-import com.nike.riposte.client.asynchttp.ning.AsyncHttpClientHelper;
-import com.nike.riposte.client.asynchttp.ning.AsyncResponseHandler;
-import com.nike.riposte.client.asynchttp.ning.RequestBuilderWrapper;
+import com.nike.riposte.client.asynchttp.AsyncHttpClientHelper;
+import com.nike.riposte.client.asynchttp.AsyncResponseHandler;
+import com.nike.riposte.client.asynchttp.RequestBuilderWrapper;
 import com.nike.riposte.server.config.AppInfo;
 import com.nike.riposte.server.config.impl.AppInfoImpl;
 
-import com.ning.http.client.Response;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 
+import org.asynchttpclient.Response;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;


### PR DESCRIPTION
Upgrade [Async Http Client](https://github.com/AsyncHttpClient/async-http-client) from 1.x to 2.x version.

With this, refactored package name to drop `ning` as that was done in the 2.x branch and is no longer relevant