### PR TITLE
Don't strip the slash for matcher name when the path is the root path

### DIFF
--- a/riposte-spi/src/main/java/com/nike/riposte/util/MatcherUtil.java
+++ b/riposte-spi/src/main/java/com/nike/riposte/util/MatcherUtil.java
@@ -2,7 +2,6 @@ package com.nike.riposte.util;
 
 import org.jetbrains.annotations.NotNull;
 
-@SuppressWarnings("WeakerAccess")
 public class MatcherUtil {
 
     // Intentionally protected - use the static methods
@@ -10,6 +9,11 @@ public class MatcherUtil {
 
     public static String stripEndSlash(@NotNull String path) {
         if (path.endsWith("/")) {
+            if (path.length() == 1) {
+                // The path is only a slash. i.e. it's the root path. In that case we don't want to strip the slash.
+                return path;
+            }
+
             return path.substring(0, path.length() - 1);
         } else {
             return path;

--- a/riposte-spi/src/test/java/com/nike/riposte/util/MatcherUtilTest.java
+++ b/riposte-spi/src/test/java/com/nike/riposte/util/MatcherUtilTest.java
@@ -2,8 +2,7 @@ package com.nike.riposte.util;
 
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests the functionality of {@link MatcherUtil}
@@ -19,6 +18,15 @@ public class MatcherUtilTest {
     @Test
     public void stripEndSlash_should_strip_an_end_slash() {
         String path = "/something/ending/in/slash/";
-        assertThat(MatcherUtil.stripEndSlash(path), is("/something/ending/in/slash"));
+        assertThat(MatcherUtil.stripEndSlash(path)).isEqualTo("/something/ending/in/slash");
+    }
+
+    @Test
+    public void stripEndSlash_does_nothing_if_path_is_root_path() {
+        // when
+        String result = MatcherUtil.stripEndSlash("/");
+
+        // then
+        assertThat(result).isEqualTo("/");
     }
 }


### PR DESCRIPTION
This mainly affects the span name for the overall request if you have an endpoint listening on the '/' root path.